### PR TITLE
Create Pydnatic validators to safely load manifest files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
         entry: check-yaml
         language: system
         types: [yaml]
+        exclude: ^src/dbt_jinja_tests/templates/
       - id: darglint
         name: darglint
         entry: darglint

--- a/noxfile.py
+++ b/noxfile.py
@@ -143,7 +143,14 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    session.run("safety", "check", "--full-report", f"--file={requirements}")
+    session.run(
+        "safety",
+        "check",
+        "--full-report",
+        f"--file={requirements}",
+        "--ignore",
+        "50571",
+    )
 
 
 @session(python=python_versions)

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,30 +7,22 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.0"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "babel"
-version = "2.10.1"
+version = "2.10.3"
 description = "Internationalization utilities"
 category = "dev"
 optional = false
@@ -75,18 +67,18 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "22.3.0"
+version = "22.10.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.7"
 
 [package.dependencies]
 click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
@@ -98,7 +90,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2022.5.18.1"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
@@ -114,11 +106,11 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.12"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "dev"
 optional = false
-python-versions = ">=3.5.0"
+python-versions = ">=3.6.0"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
@@ -137,11 +129,11 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
 [[package]]
 name = "coverage"
@@ -167,7 +159,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "distlib"
-version = "0.3.4"
+version = "0.3.6"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -183,7 +175,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "dparse"
-version = "0.5.1"
+version = "0.6.2"
 description = "A parser for Python dependency files"
 category = "dev"
 optional = false
@@ -191,41 +183,52 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 packaging = "*"
-pyyaml = "*"
 toml = "*"
 
 [package.extras]
+conda = ["pyyaml"]
 pipenv = ["pipenv"]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.0.0rc9"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "filelock"
-version = "3.7.1"
+version = "3.8.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
-testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flake8"
-version = "4.0.1"
+version = "5.0.4"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.1"
 
 [package.dependencies]
-importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.8.0,<2.9.0"
-pyflakes = ">=2.4.0,<2.5.0"
+importlib-metadata = {version = ">=1.1.0,<4.3", markers = "python_version < \"3.8\""}
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.9.0,<2.10.0"
+pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "flake8-bandit"
-version = "3.0.0"
+version = "4.1.1"
 description = "Automated security testing with bandit and flake8."
 category = "dev"
 optional = false
@@ -233,24 +236,22 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 bandit = ">=1.7.3"
-flake8 = "*"
-flake8-polyfill = "*"
-pycodestyle = "*"
+flake8 = ">=5.0.0"
 
 [[package]]
 name = "flake8-bugbear"
-version = "22.4.25"
+version = "22.10.25"
 description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=19.2.0"
 flake8 = ">=3.0.0"
 
 [package.extras]
-dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit"]
+dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit", "tox"]
 
 [[package]]
 name = "flake8-docstrings"
@@ -265,23 +266,12 @@ flake8 = ">=3"
 pydocstyle = ">=2.1"
 
 [[package]]
-name = "flake8-polyfill"
-version = "1.0.2"
-description = "Polyfill package for Flake8 plugins"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = "*"
-
-[[package]]
 name = "flake8-rst-docstrings"
-version = "0.2.5"
+version = "0.2.7"
 description = "Python docstring reStructuredText (RST) validator"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 flake8 = ">=3.0.0"
@@ -290,16 +280,17 @@ restructuredtext-lint = "*"
 
 [[package]]
 name = "furo"
-version = "2022.4.7"
+version = "2022.9.29"
 description = "A clean customisable Sphinx documentation theme."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 beautifulsoup4 = "*"
-pygments = ">=2.7,<3.0"
-sphinx = ">=4.0,<5.0"
+pygments = ">=2.7"
+sphinx = ">=4.0,<6.0"
+sphinx-basic-ng = "*"
 
 [[package]]
 name = "gitdb"
@@ -314,7 +305,7 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.27"
+version = "3.1.29"
 description = "GitPython is a python library used to interact with Git repositories"
 category = "dev"
 optional = false
@@ -326,7 +317,7 @@ typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""
 
 [[package]]
 name = "identify"
-version = "2.5.1"
+version = "2.5.7"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -337,7 +328,7 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "dev"
 optional = false
@@ -345,7 +336,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imagesize"
-version = "1.3.0"
+version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "dev"
 optional = false
@@ -447,31 +438,31 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "mccabe"
-version = "0.6.1"
+version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.3.0"
+version = "0.3.1"
 description = "Collection of plugins for markdown-it-py"
 category = "dev"
 optional = false
-python-versions = "~=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-code_style = ["pre-commit (==2.6)"]
-rtd = ["myst-parser (>=0.14.0,<0.15.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
-testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
+code_style = ["pre-commit"]
+rtd = ["attrs", "myst-parser (>=0.16.1,<0.17.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "mdurl"
-version = "0.1.1"
+version = "0.1.2"
 description = "Markdown URL utilities"
 category = "dev"
 optional = false
@@ -479,11 +470,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "mypy"
-version = "0.960"
+version = "0.982"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
@@ -506,34 +497,34 @@ python-versions = "*"
 
 [[package]]
 name = "myst-parser"
-version = "0.17.2"
+version = "0.18.1"
 description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-docutils = ">=0.15,<0.18"
+docutils = ">=0.15,<0.20"
 jinja2 = "*"
 markdown-it-py = ">=1.0.0,<3.0.0"
-mdit-py-plugins = ">=0.3.0,<0.4.0"
+mdit-py-plugins = ">=0.3.1,<0.4.0"
 pyyaml = "*"
-sphinx = ">=3.1,<5"
+sphinx = ">=4,<6"
 typing-extensions = "*"
 
 [package.extras]
 code_style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
-rtd = ["ipython", "sphinx-book-theme", "sphinx-panels", "sphinxcontrib-bibtex (>=2.4,<3.0)", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
-testing = ["beautifulsoup4", "coverage", "docutils (>=0.17.0,<0.18.0)", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions"]
+rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
+testing = ["beautifulsoup4", "coverage", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx (<5.2)", "sphinx-pytest"]
 
 [[package]]
 name = "nodeenv"
-version = "1.6.0"
+version = "1.7.0"
 description = "Node.js virtual environment builder"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 
 [[package]]
 name = "packaging"
@@ -548,15 +539,15 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pbr"
-version = "5.9.0"
+version = "5.11.0"
 description = "Python Build Reasonableness"
 category = "dev"
 optional = false
@@ -564,11 +555,11 @@ python-versions = ">=2.6"
 
 [[package]]
 name = "pep8-naming"
-version = "0.13.0"
+version = "0.13.2"
 description = "Check PEP-8 naming conventions, plugin for flake8"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 
 [package.dependencies]
 flake8 = ">=3.9.1"
@@ -602,7 +593,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.19.0"
+version = "2.20.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -619,7 +610,7 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "pre-commit-hooks"
-version = "4.2.0"
+version = "4.3.0"
 description = "Some out-of-the-box hooks for pre-commit."
 category = "dev"
 optional = false
@@ -627,23 +618,15 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 "ruamel.yaml" = ">=0.15"
-toml = "*"
-
-[[package]]
-name = "py"
-version = "1.11.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "pycodestyle"
-version = "2.8.0"
+version = "2.9.1"
 description = "Python style guide checker"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pydantic"
@@ -676,19 +659,22 @@ toml = ["toml"]
 
 [[package]]
 name = "pyflakes"
-version = "2.4.0"
+version = "2.5.0"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pygments"
-version = "2.12.0"
+version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[package.extras]
+plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pyparsing"
@@ -703,29 +689,28 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.1.2"
+version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-tomli = ">=1.0.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytz"
-version = "2022.1"
+version = "2022.5"
 description = "World timezone definitions, modern and historical"
 category = "dev"
 optional = false
@@ -733,7 +718,7 @@ python-versions = "*"
 
 [[package]]
 name = "pyupgrade"
-version = "2.32.1"
+version = "3.1.0"
 description = "A tool to automatically upgrade syntax for newer versions."
 category = "dev"
 optional = false
@@ -752,21 +737,21 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "restructuredtext-lint"
@@ -781,14 +766,14 @@ docutils = ">=0.11,<1.0"
 
 [[package]]
 name = "ruamel.yaml"
-version = "0.17.17"
+version = "0.17.21"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 category = "dev"
 optional = false
 python-versions = ">=3"
 
 [package.dependencies]
-"ruamel.yaml.clib" = {version = ">=0.1.2", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.10\""}
+"ruamel.yaml.clib" = {version = ">=0.2.6", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.11\""}
 
 [package.extras]
 docs = ["ryd"]
@@ -796,7 +781,7 @@ jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
 
 [[package]]
 name = "ruamel.yaml.clib"
-version = "0.2.6"
+version = "0.2.7"
 description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
 category = "dev"
 optional = false
@@ -804,17 +789,22 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "safety"
-version = "1.10.3"
-description = "Checks installed dependencies for known vulnerabilities."
+version = "2.3.1"
+description = "Checks installed dependencies for known vulnerabilities and licenses."
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = "*"
 
 [package.dependencies]
-Click = ">=6.0"
-dparse = ">=0.5.1"
-packaging = "*"
+Click = ">=8.0.2"
+dparse = ">=0.6.2"
+packaging = ">=21.0"
 requests = "*"
+"ruamel.yaml" = ">=0.17.21"
+
+[package.extras]
+github = ["jinja2 (>=3.1.0)", "pygithub (>=1.43.3)"]
+gitlab = ["python-gitlab (>=1.3.0)"]
 
 [[package]]
 name = "six"
@@ -896,8 +886,22 @@ sphinx = "*"
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "sphinx-basic-ng"
+version = "1.0.0b1"
+description = "A modern skeleton for Sphinx themes."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+sphinx = ">=4.0"
+
+[package.extras]
+docs = ["furo", "ipython", "myst-parser", "sphinx-copybutton", "sphinx-inline-tabs"]
+
+[[package]]
 name = "sphinx-click"
-version = "4.1.0"
+version = "4.3.0"
 description = "Sphinx extension that automatically documents click applications"
 category = "dev"
 optional = false
@@ -981,7 +985,7 @@ test = ["pytest"]
 
 [[package]]
 name = "stevedore"
-version = "3.5.0"
+version = "3.5.2"
 description = "Manage dynamic plugins for Python applications"
 category = "dev"
 optional = false
@@ -993,11 +997,11 @@ pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
 name = "tokenize-rt"
-version = "4.2.1"
+version = "5.0.0"
 description = "A wrapper around the stdlib `tokenize` which roundtrips."
 category = "dev"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7"
 
 [[package]]
 name = "toml"
@@ -1017,11 +1021,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tornado"
-version = "6.1"
+version = "6.2"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 category = "dev"
 optional = false
-python-versions = ">= 3.5"
+python-versions = ">= 3.7"
 
 [[package]]
 name = "typed-ast"
@@ -1045,7 +1049,7 @@ test = ["mypy", "pytest", "typing-extensions"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.2.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -1053,31 +1057,30 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.9"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.14.1"
+version = "20.16.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 platformdirs = ">=2,<3"
-six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
@@ -1109,15 +1112,15 @@ tests-strict = ["cmake (==3.21.2)", "codecov (==2.0.15)", "ninja (==1.10.2)", "p
 
 [[package]]
 name = "zipp"
-version = "3.8.0"
+version = "3.10.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
@@ -1129,67 +1132,58 @@ alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
-atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
-]
 attrs = [
-    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
-    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
-babel = [
-    {file = "Babel-2.10.1-py3-none-any.whl", hash = "sha256:3f349e85ad3154559ac4930c3918247d319f21910d5ce4b25d439ed8693b98d2"},
-    {file = "Babel-2.10.1.tar.gz", hash = "sha256:98aeaca086133efb3e1e2aad0396987490c8425929ddbcfe0550184fdc54cd13"},
-]
+babel = []
 bandit = [
     {file = "bandit-1.7.4-py3-none-any.whl", hash = "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"},
     {file = "bandit-1.7.4.tar.gz", hash = "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2"},
 ]
 beautifulsoup4 = []
 black = [
-    {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
-    {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
-    {file = "black-22.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a"},
-    {file = "black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968"},
-    {file = "black-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"},
-    {file = "black-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce"},
-    {file = "black-22.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82"},
-    {file = "black-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b"},
-    {file = "black-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015"},
-    {file = "black-22.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b"},
-    {file = "black-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a"},
-    {file = "black-22.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163"},
-    {file = "black-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464"},
-    {file = "black-22.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0"},
-    {file = "black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176"},
-    {file = "black-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0"},
-    {file = "black-22.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20"},
-    {file = "black-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a"},
-    {file = "black-22.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad"},
-    {file = "black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21"},
-    {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
-    {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
-    {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
+    {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
+    {file = "black-22.10.0-1fixedarch-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef"},
+    {file = "black-22.10.0-1fixedarch-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6"},
+    {file = "black-22.10.0-1fixedarch-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d"},
+    {file = "black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4"},
+    {file = "black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb"},
+    {file = "black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7"},
+    {file = "black-22.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66"},
+    {file = "black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae"},
+    {file = "black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b"},
+    {file = "black-22.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d"},
+    {file = "black-22.10.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650"},
+    {file = "black-22.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d"},
+    {file = "black-22.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"},
+    {file = "black-22.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87"},
+    {file = "black-22.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395"},
+    {file = "black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0"},
+    {file = "black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383"},
+    {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
+    {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
+    {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
 ]
 certifi = [
-    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
-    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+    {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
+    {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
 ]
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
 ]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 coverage = [
     {file = "coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53"},
@@ -1248,68 +1242,68 @@ darglint = [
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
 ]
 distlib = [
-    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
-    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
     {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
 ]
 dparse = [
-    {file = "dparse-0.5.1-py3-none-any.whl", hash = "sha256:e953a25e44ebb60a5c6efc2add4420c177f1d8404509da88da9729202f306994"},
-    {file = "dparse-0.5.1.tar.gz", hash = "sha256:a1b5f169102e1c894f9a7d5ccf6f9402a836a5d24be80a986c7ce9eaed78f367"},
+    {file = "dparse-0.6.2-py3-none-any.whl", hash = "sha256:8097076f1dd26c377f30d4745e6ec18fef42f3bf493933b842ac5bafad8c345f"},
+    {file = "dparse-0.6.2.tar.gz", hash = "sha256:d45255bda21f998bc7ddf2afd5e62505ba6134756ba2d42a84c56b0826614dfe"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
+    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
 ]
 filelock = [
-    {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
-    {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
+    {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
+    {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
 ]
 flake8 = [
-    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
-    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
+    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
 ]
 flake8-bandit = [
-    {file = "flake8_bandit-3.0.0-py2.py3-none-any.whl", hash = "sha256:61b617f4f7cdaa0e2b1e6bf7b68afb2b619a227bb3e3ae00dd36c213bd17900a"},
-    {file = "flake8_bandit-3.0.0.tar.gz", hash = "sha256:54d19427e6a8d50322a7b02e1841c0a7c22d856975f3459803320e0e18e2d6a1"},
+    {file = "flake8_bandit-4.1.1-py3-none-any.whl", hash = "sha256:4c8a53eb48f23d4ef1e59293657181a3c989d0077c9952717e98a0eace43e06d"},
+    {file = "flake8_bandit-4.1.1.tar.gz", hash = "sha256:068e09287189cbfd7f986e92605adea2067630b75380c6b5733dab7d87f9a84e"},
 ]
 flake8-bugbear = [
-    {file = "flake8-bugbear-22.4.25.tar.gz", hash = "sha256:f7c080563fca75ee6b205d06b181ecba22b802babb96b0b084cc7743d6908a55"},
-    {file = "flake8_bugbear-22.4.25-py3-none-any.whl", hash = "sha256:ec374101cddf65bd7a96d393847d74e58d3b98669dbf9768344c39b6290e8bd6"},
+    {file = "flake8-bugbear-22.10.25.tar.gz", hash = "sha256:89e51284eb929fbb7f23fbd428491e7427f7cdc8b45a77248daffe86a039d696"},
+    {file = "flake8_bugbear-22.10.25-py3-none-any.whl", hash = "sha256:584631b608dc0d7d3f9201046d5840a45502da4732d5e8df6c7ac1694a91cb9e"},
 ]
 flake8-docstrings = [
     {file = "flake8-docstrings-1.6.0.tar.gz", hash = "sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b"},
     {file = "flake8_docstrings-1.6.0-py2.py3-none-any.whl", hash = "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde"},
 ]
-flake8-polyfill = [
-    {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
-    {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
-]
 flake8-rst-docstrings = [
-    {file = "flake8-rst-docstrings-0.2.5.tar.gz", hash = "sha256:4fe93f997dea45d9d3c8bd220f12f0b6c359948fb943b5b48021a3f927edd816"},
-    {file = "flake8_rst_docstrings-0.2.5-py3-none-any.whl", hash = "sha256:b99d9041b769b857efe45a448dc8c71b1bb311f9cacbdac5de82f96498105082"},
+    {file = "flake8-rst-docstrings-0.2.7.tar.gz", hash = "sha256:2740067ab9237559dd45a3434d8c987792c7b259ca563621a3b95efe201f5382"},
+    {file = "flake8_rst_docstrings-0.2.7-py3-none-any.whl", hash = "sha256:5d56075dce360bcc9c6775bfe7cb431aa395de600ca7e8d40580a28d50b2a803"},
 ]
 furo = [
-    {file = "furo-2022.4.7-py3-none-any.whl", hash = "sha256:7f3e3d2fb977483590f8ecb2c2cd511bd82661b79c18efb24de9558bc9cdf2d7"},
-    {file = "furo-2022.4.7.tar.gz", hash = "sha256:96204ab7cd047e4b6c523996e0279c4c629a8fc31f4f109b2efd470c17f49c80"},
+    {file = "furo-2022.9.29-py3-none-any.whl", hash = "sha256:559ee17999c0f52728481dcf6b1b0cf8c9743e68c5e3a18cb45a7992747869a9"},
+    {file = "furo-2022.9.29.tar.gz", hash = "sha256:d4238145629c623609c2deb5384f8d036e2a1ee2a101d64b67b4348112470dbd"},
 ]
 gitdb = [
     {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
     {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.27-py3-none-any.whl", hash = "sha256:5b68b000463593e05ff2b261acff0ff0972df8ab1b70d3cdbd41b546c8b8fc3d"},
-    {file = "GitPython-3.1.27.tar.gz", hash = "sha256:1c885ce809e8ba2d88a29befeb385fcea06338d3640712b59ca623c220bb5704"},
+    {file = "GitPython-3.1.29-py3-none-any.whl", hash = "sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f"},
+    {file = "GitPython-3.1.29.tar.gz", hash = "sha256:cc36bfc4a3f913e66805a28e84703e419d9c264c1077e537b54f0e1af85dbefd"},
 ]
 identify = [
-    {file = "identify-2.5.1-py2.py3-none-any.whl", hash = "sha256:0dca2ea3e4381c435ef9c33ba100a78a9b40c0bab11189c7cf121f75815efeaa"},
-    {file = "identify-2.5.1.tar.gz", hash = "sha256:3d11b16f3fe19f52039fb7e39c9c884b21cb1b586988114fbe42671f03de3e82"},
+    {file = "identify-2.5.7-py2.py3-none-any.whl", hash = "sha256:7a67b2a6208d390fd86fd04fb3def94a3a8b7f0bcbd1d1fcd6736f4defe26390"},
+    {file = "identify-2.5.7.tar.gz", hash = "sha256:5b8fd1e843a6d4bf10685dd31f4520a7f1c7d0e14e9bc5d34b1d6f111cabc011"},
 ]
 idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 imagesize = [
-    {file = "imagesize-1.3.0-py2.py3-none-any.whl", hash = "sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c"},
-    {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
+    {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
+    {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
@@ -1333,69 +1327,70 @@ markdown-it-py = [
 ]
 markupsafe = []
 mccabe = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 mdit-py-plugins = [
-    {file = "mdit-py-plugins-0.3.0.tar.gz", hash = "sha256:ecc24f51eeec6ab7eecc2f9724e8272c2fb191c2e93cf98109120c2cace69750"},
-    {file = "mdit_py_plugins-0.3.0-py3-none-any.whl", hash = "sha256:b1279701cee2dbf50e188d3da5f51fee8d78d038cdf99be57c6b9d1aa93b4073"},
+    {file = "mdit-py-plugins-0.3.1.tar.gz", hash = "sha256:3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441"},
+    {file = "mdit_py_plugins-0.3.1-py3-none-any.whl", hash = "sha256:606a7f29cf56dbdfaf914acb21709b8f8ee29d857e8f29dcc33d8cb84c57bfa1"},
 ]
 mdurl = [
-    {file = "mdurl-0.1.1-py3-none-any.whl", hash = "sha256:6a8f6804087b7128040b2fb2ebe242bdc2affaeaa034d5fc9feeed30b443651b"},
-    {file = "mdurl-0.1.1.tar.gz", hash = "sha256:f79c9709944df218a4cdb0fcc0b0c7ead2f44594e3e84dc566606f04ad749c20"},
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 mypy = [
-    {file = "mypy-0.960-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3a3e525cd76c2c4f90f1449fd034ba21fcca68050ff7c8397bb7dd25dd8b8248"},
-    {file = "mypy-0.960-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7a76dc4f91e92db119b1be293892df8379b08fd31795bb44e0ff84256d34c251"},
-    {file = "mypy-0.960-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ffdad80a92c100d1b0fe3d3cf1a4724136029a29afe8566404c0146747114382"},
-    {file = "mypy-0.960-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7d390248ec07fa344b9f365e6ed9d205bd0205e485c555bed37c4235c868e9d5"},
-    {file = "mypy-0.960-cp310-cp310-win_amd64.whl", hash = "sha256:925aa84369a07846b7f3b8556ccade1f371aa554f2bd4fb31cb97a24b73b036e"},
-    {file = "mypy-0.960-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:239d6b2242d6c7f5822163ee082ef7a28ee02e7ac86c35593ef923796826a385"},
-    {file = "mypy-0.960-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f1ba54d440d4feee49d8768ea952137316d454b15301c44403db3f2cb51af024"},
-    {file = "mypy-0.960-cp36-cp36m-win_amd64.whl", hash = "sha256:cb7752b24528c118a7403ee955b6a578bfcf5879d5ee91790667c8ea511d2085"},
-    {file = "mypy-0.960-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:826a2917c275e2ee05b7c7b736c1e6549a35b7ea5a198ca457f8c2ebea2cbecf"},
-    {file = "mypy-0.960-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3eabcbd2525f295da322dff8175258f3fc4c3eb53f6d1929644ef4d99b92e72d"},
-    {file = "mypy-0.960-cp37-cp37m-win_amd64.whl", hash = "sha256:f47322796c412271f5aea48381a528a613f33e0a115452d03ae35d673e6064f8"},
-    {file = "mypy-0.960-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2c7f8bb9619290836a4e167e2ef1f2cf14d70e0bc36c04441e41487456561409"},
-    {file = "mypy-0.960-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fbfb873cf2b8d8c3c513367febde932e061a5f73f762896826ba06391d932b2a"},
-    {file = "mypy-0.960-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cc537885891382e08129d9862553b3d00d4be3eb15b8cae9e2466452f52b0117"},
-    {file = "mypy-0.960-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:481f98c6b24383188c928f33dd2f0776690807e12e9989dd0419edd5c74aa53b"},
-    {file = "mypy-0.960-cp38-cp38-win_amd64.whl", hash = "sha256:29dc94d9215c3eb80ac3c2ad29d0c22628accfb060348fd23d73abe3ace6c10d"},
-    {file = "mypy-0.960-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:33d53a232bb79057f33332dbbb6393e68acbcb776d2f571ba4b1d50a2c8ba873"},
-    {file = "mypy-0.960-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8d645e9e7f7a5da3ec3bbcc314ebb9bb22c7ce39e70367830eb3c08d0140b9ce"},
-    {file = "mypy-0.960-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:85cf2b14d32b61db24ade8ac9ae7691bdfc572a403e3cb8537da936e74713275"},
-    {file = "mypy-0.960-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a85a20b43fa69efc0b955eba1db435e2ffecb1ca695fe359768e0503b91ea89f"},
-    {file = "mypy-0.960-cp39-cp39-win_amd64.whl", hash = "sha256:0ebfb3f414204b98c06791af37a3a96772203da60636e2897408517fcfeee7a8"},
-    {file = "mypy-0.960-py3-none-any.whl", hash = "sha256:bfd4f6536bd384c27c392a8b8f790fd0ed5c0cf2f63fc2fed7bce56751d53026"},
-    {file = "mypy-0.960.tar.gz", hash = "sha256:d4fccf04c1acf750babd74252e0f2db6bd2ac3aa8fe960797d9f3ef41cf2bfd4"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3"},
+    {file = "mypy-0.982-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"},
+    {file = "mypy-0.982-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6"},
+    {file = "mypy-0.982-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046"},
+    {file = "mypy-0.982-cp310-cp310-win_amd64.whl", hash = "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e"},
+    {file = "mypy-0.982-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20"},
+    {file = "mypy-0.982-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947"},
+    {file = "mypy-0.982-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40"},
+    {file = "mypy-0.982-cp37-cp37m-win_amd64.whl", hash = "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e"},
+    {file = "mypy-0.982-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda"},
+    {file = "mypy-0.982-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206"},
+    {file = "mypy-0.982-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763"},
+    {file = "mypy-0.982-cp38-cp38-win_amd64.whl", hash = "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146"},
+    {file = "mypy-0.982-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc"},
+    {file = "mypy-0.982-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b"},
+    {file = "mypy-0.982-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a"},
+    {file = "mypy-0.982-cp39-cp39-win_amd64.whl", hash = "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795"},
+    {file = "mypy-0.982-py3-none-any.whl", hash = "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d"},
+    {file = "mypy-0.982.tar.gz", hash = "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 myst-parser = [
-    {file = "myst-parser-0.17.2.tar.gz", hash = "sha256:4c076d649e066f9f5c7c661bae2658be1ca06e76b002bb97f02a09398707686c"},
-    {file = "myst_parser-0.17.2-py3-none-any.whl", hash = "sha256:1635ce3c18965a528d6de980f989ff64d6a1effb482e1f611b1bfb79e38f3d98"},
+    {file = "myst-parser-0.18.1.tar.gz", hash = "sha256:79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d"},
+    {file = "myst_parser-0.18.1-py3-none-any.whl", hash = "sha256:61b275b85d9f58aa327f370913ae1bec26ebad372cc99f3ab85c8ec3ee8d9fb8"},
 ]
 nodeenv = [
-    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
-    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
+    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
+    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
 ]
 pbr = [
-    {file = "pbr-5.9.0-py2.py3-none-any.whl", hash = "sha256:e547125940bcc052856ded43be8e101f63828c2d94239ffbe2b327ba3d5ccf0a"},
-    {file = "pbr-5.9.0.tar.gz", hash = "sha256:e8dca2f4b43560edef58813969f52a56cef023146cbb8931626db80e6c1c4308"},
+    {file = "pbr-5.11.0-py2.py3-none-any.whl", hash = "sha256:db2317ff07c84c4c63648c9064a79fe9d9f5c7ce85a9099d4b6258b3db83225a"},
+    {file = "pbr-5.11.0.tar.gz", hash = "sha256:b97bc6695b2aff02144133c2e7399d5885223d42b7912ffaec2ca3898e673bfe"},
 ]
 pep8-naming = [
-    {file = "pep8-naming-0.13.0.tar.gz", hash = "sha256:9f38e6dcf867a1fb7ad47f5ff72c0ddae544a6cf64eb9f7600b7b3c0bb5980b5"},
-    {file = "pep8_naming-0.13.0-py3-none-any.whl", hash = "sha256:069ea20e97f073b3e6d4f789af2a57816f281ca64b86210c7d471117a4b6bfd0"},
+    {file = "pep8-naming-0.13.2.tar.gz", hash = "sha256:93eef62f525fd12a6f8c98f4dcc17fa70baae2f37fa1f73bec00e3e44392fa48"},
+    {file = "pep8_naming-0.13.2-py3-none-any.whl", hash = "sha256:59e29e55c478db69cffbe14ab24b5bd2cd615c0413edf790d47d3fb7ba9a4e23"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -1406,20 +1401,16 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.19.0-py2.py3-none-any.whl", hash = "sha256:10c62741aa5704faea2ad69cb550ca78082efe5697d6f04e5710c3c229afdd10"},
-    {file = "pre_commit-2.19.0.tar.gz", hash = "sha256:4233a1e38621c87d9dda9808c6606d7e7ba0e087cd56d3fe03202a01d2919615"},
+    {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
+    {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
 ]
 pre-commit-hooks = [
-    {file = "pre_commit_hooks-4.2.0-py2.py3-none-any.whl", hash = "sha256:b3a3066c5ecd5fdda9abdc932bd064bd21785ea041659676403e6fc5d964afed"},
-    {file = "pre_commit_hooks-4.2.0.tar.gz", hash = "sha256:9726420c7a071e8cb233a066d36bc074b593a40f0b1b491d1b75aafa55390703"},
-]
-py = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+    {file = "pre_commit_hooks-4.3.0-py2.py3-none-any.whl", hash = "sha256:9ccaf7c98794659d345080ee1ea0256a55ae059675045eebdbbc17c0be8c7e4b"},
+    {file = "pre_commit_hooks-4.3.0.tar.gz", hash = "sha256:fda598a4c834d030727e6a615722718b47510f4bed72df4c949f95ba9f5aaf88"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
-    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
+    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
 ]
 pydantic = [
     {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
@@ -1464,19 +1455,25 @@ pydocstyle = [
     {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
-    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
+    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
+    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
-pygments = []
+pygments = [
+    {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
+    {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
+]
 pyparsing = []
 pytest = [
-    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
-    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
+    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
+    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
 ]
-pytz = []
+pytz = [
+    {file = "pytz-2022.5-py2.py3-none-any.whl", hash = "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22"},
+    {file = "pytz-2022.5.tar.gz", hash = "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"},
+]
 pyupgrade = [
-    {file = "pyupgrade-2.32.1-py2.py3-none-any.whl", hash = "sha256:d874f34870abadd7536c89678f9811076d5df93c13620f90a125355a2d31fa91"},
-    {file = "pyupgrade-2.32.1.tar.gz", hash = "sha256:11e2c3e4e2e53a61b2d8852ed154ea5683887b6ac42561622ca8d89c94fd951a"},
+    {file = "pyupgrade-3.1.0-py2.py3-none-any.whl", hash = "sha256:77c6101a710be3e24804891e43388cedbee617258e93b09c8c5e58de08617758"},
+    {file = "pyupgrade-3.1.0.tar.gz", hash = "sha256:7a8d393d85e15e0e2753e90b7b2e173b9d29dfd71e61f93d93e985b242627ed3"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -1513,52 +1510,52 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
-requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
-]
+requests = []
 restructuredtext-lint = [
     {file = "restructuredtext_lint-1.4.0.tar.gz", hash = "sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"},
 ]
 "ruamel.yaml" = [
-    {file = "ruamel.yaml-0.17.17-py3-none-any.whl", hash = "sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f"},
-    {file = "ruamel.yaml-0.17.17.tar.gz", hash = "sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be"},
+    {file = "ruamel.yaml-0.17.21-py3-none-any.whl", hash = "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7"},
+    {file = "ruamel.yaml-0.17.21.tar.gz", hash = "sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"},
 ]
 "ruamel.yaml.clib" = [
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:066f886bc90cc2ce44df8b5f7acfc6a7e2b2e672713f027136464492b0c34d7c"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win32.whl", hash = "sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de"},
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751"},
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527"},
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win32.whl", hash = "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5"},
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win_amd64.whl", hash = "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d3c620a54748a3d4cf0bcfe623e388407c8e85a4b06b8188e126302bcab93ea8"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-win32.whl", hash = "sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-win_amd64.whl", hash = "sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:210c8fcfeff90514b7133010bf14e3bad652c8efde6b20e00c43854bf94fa5a6"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-win32.whl", hash = "sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-win_amd64.whl", hash = "sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:61bc5e5ca632d95925907c569daa559ea194a4d16084ba86084be98ab1cec1c6"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-win32.whl", hash = "sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-win_amd64.whl", hash = "sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1b4139a6ffbca8ef60fdaf9b33dec05143ba746a6f0ae0f9d11d38239211d335"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-win32.whl", hash = "sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-win_amd64.whl", hash = "sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7"},
-    {file = "ruamel.yaml.clib-0.2.6.tar.gz", hash = "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5859983f26d8cd7bb5c287ef452e8aacc86501487634573d260968f753e1d71"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:debc87a9516b237d0466a711b18b6ebeb17ba9f391eb7f91c649c5c4ec5006c7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:df5828871e6648db72d1c19b4bd24819b80a755c4541d3409f0f7acd0f335c80"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:efa08d63ef03d079dcae1dfe334f6c8847ba8b645d08df286358b1f5293d24ab"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:370445fd795706fd291ab00c9df38a0caed0f17a6fb46b0f607668ecb16ce763"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win32.whl", hash = "sha256:ecdf1a604009bd35c674b9225a8fa609e0282d9b896c03dd441a91e5f53b534e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win_amd64.whl", hash = "sha256:f34019dced51047d6f70cb9383b2ae2853b7fc4dce65129a5acd49f4f9256646"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2aa261c29a5545adfef9296b7e33941f46aa5bbd21164228e833412af4c9c75f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f01da5790e95815eb5a8a138508c01c758e5f5bc0ce4286c4f7028b8dd7ac3d0"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:40d030e2329ce5286d6b231b8726959ebbe0404c92f0a578c0e2482182e38282"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c3ca1fbba4ae962521e5eb66d72998b51f0f4d0f608d3c0347a48e1af262efa7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win32.whl", hash = "sha256:7bdb4c06b063f6fd55e472e201317a3bb6cdeeee5d5a38512ea5c01e1acbdd93"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win_amd64.whl", hash = "sha256:be2a7ad8fd8f7442b24323d24ba0b56c51219513cfa45b9ada3b87b76c374d4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:91a789b4aa0097b78c93e3dc4b40040ba55bef518f84a40d4442f713b4094acb"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:99e77daab5d13a48a4054803d052ff40780278240a902b880dd37a51ba01a307"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3243f48ecd450eddadc2d11b5feb08aca941b5cd98c9b1db14b2fd128be8c697"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8831a2cedcd0f0927f788c5bdf6567d9dc9cc235646a434986a852af1cb54b4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win32.whl", hash = "sha256:3110a99e0f94a4a3470ff67fc20d3f96c25b13d24c6980ff841e82bafe827cac"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win_amd64.whl", hash = "sha256:92460ce908546ab69770b2e576e4f99fbb4ce6ab4b245345a3869a0a0410488f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5bc0667c1eb8f83a3752b71b9c4ba55ef7c7058ae57022dd9b29065186a113d9"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:4a4d8d417868d68b979076a9be6a38c676eca060785abaa6709c7b31593c35d1"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bf9a6bc4a0221538b1a7de3ed7bca4c93c02346853f44e1cd764be0023cd3640"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a7b301ff08055d73223058b5c46c55638917f04d21577c95e00e0c4d79201a6b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win32.whl", hash = "sha256:d5e51e2901ec2366b79f16c2299a03e74ba4531ddcfacc1416639c557aef0ad8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:184faeaec61dbaa3cace407cffc5819f7b977e75360e8d5ca19461cd851a5fc5"},
+    {file = "ruamel.yaml.clib-0.2.7.tar.gz", hash = "sha256:1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497"},
 ]
 safety = [
-    {file = "safety-1.10.3-py2.py3-none-any.whl", hash = "sha256:5f802ad5df5614f9622d8d71fedec2757099705c2356f862847c58c6dfe13e84"},
-    {file = "safety-1.10.3.tar.gz", hash = "sha256:30e394d02a20ac49b7f65292d19d38fa927a8f9582cdfd3ad1adbbc66c641ad5"},
+    {file = "safety-2.3.1-py3-none-any.whl", hash = "sha256:8f098d12b607db2756886280e85c28ece8db1bba4f45fc5f981f4663217bd619"},
+    {file = "safety-2.3.1.tar.gz", hash = "sha256:6e6fcb7d4e8321098cf289f59b65051cafd3467f089c6e57c9f894ae32c23b71"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1581,9 +1578,13 @@ sphinx-autobuild = [
     {file = "sphinx-autobuild-2021.3.14.tar.gz", hash = "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05"},
     {file = "sphinx_autobuild-2021.3.14-py3-none-any.whl", hash = "sha256:8fe8cbfdb75db04475232f05187c776f46f6e9e04cacf1e49ce81bdac649ccac"},
 ]
+sphinx-basic-ng = [
+    {file = "sphinx_basic_ng-1.0.0b1-py3-none-any.whl", hash = "sha256:ade597a3029c7865b24ad0eda88318766bcc2f9f4cef60df7e28126fde94db2a"},
+    {file = "sphinx_basic_ng-1.0.0b1.tar.gz", hash = "sha256:89374bd3ccd9452a301786781e28c8718e99960f2d4f411845ea75fc7bb5a9b0"},
+]
 sphinx-click = [
-    {file = "sphinx-click-4.1.0.tar.gz", hash = "sha256:fedebd39991243ec5cfa1c9e483db7ea2621b3df2012315c89c6f1f3722f192b"},
-    {file = "sphinx_click-4.1.0-py3-none-any.whl", hash = "sha256:60d6507bf623e20e9cbab732d19fc4890cc36a394c82ba8e2320f9f9fdc4571e"},
+    {file = "sphinx-click-4.3.0.tar.gz", hash = "sha256:bd4db5d3c1bec345f07af07b8e28a76cfc5006d997984e38ae246bbf8b9a3b38"},
+    {file = "sphinx_click-4.3.0-py3-none-any.whl", hash = "sha256:23e85a3cb0b728a421ea773699f6acadefae171d1a764a51dd8ec5981503ccbe"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -1610,12 +1611,12 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 stevedore = [
-    {file = "stevedore-3.5.0-py3-none-any.whl", hash = "sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c"},
-    {file = "stevedore-3.5.0.tar.gz", hash = "sha256:f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335"},
+    {file = "stevedore-3.5.2-py3-none-any.whl", hash = "sha256:fa2630e3d0ad3e22d4914aff2501445815b9a4467a6edc49387c667a38faf5bf"},
+    {file = "stevedore-3.5.2.tar.gz", hash = "sha256:cf99f41fc0d5a4f185ca4d3d42b03be9011b0a1ec1a4ea1a282be1b4b306dcc2"},
 ]
 tokenize-rt = [
-    {file = "tokenize_rt-4.2.1-py2.py3-none-any.whl", hash = "sha256:08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8"},
-    {file = "tokenize_rt-4.2.1.tar.gz", hash = "sha256:0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94"},
+    {file = "tokenize_rt-5.0.0-py2.py3-none-any.whl", hash = "sha256:c67772c662c6b3dc65edf66808577968fb10badfc2042e3027196bed4daf9e5a"},
+    {file = "tokenize_rt-5.0.0.tar.gz", hash = "sha256:3160bc0c3e8491312d0485171dea861fc160a240f5f5766b72a1165408d10740"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
@@ -1625,49 +1626,7 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-tornado = [
-    {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9de9e5188a782be6b1ce866e8a51bc76a0fbaa0e16613823fc38e4fc2556ad05"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:61b32d06ae8a036a6607805e6720ef00a3c98207038444ba7fd3d169cd998910"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:3e63498f680547ed24d2c71e6497f24bca791aca2fe116dbc2bd0ac7f191691b"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:6c77c9937962577a6a76917845d06af6ab9197702a42e1346d8ae2e76b5e3675"},
-    {file = "tornado-6.1-cp35-cp35m-win32.whl", hash = "sha256:6286efab1ed6e74b7028327365cf7346b1d777d63ab30e21a0f4d5b275fc17d5"},
-    {file = "tornado-6.1-cp35-cp35m-win_amd64.whl", hash = "sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68"},
-    {file = "tornado-6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0a00ff4561e2929a2c37ce706cb8233b7907e0cdc22eab98888aca5dd3775feb"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:748290bf9112b581c525e6e6d3820621ff020ed95af6f17fedef416b27ed564c"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:e385b637ac3acaae8022e7e47dfa7b83d3620e432e3ecb9a3f7f58f150e50921"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:25ad220258349a12ae87ede08a7b04aca51237721f63b1808d39bdb4b2164558"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:65d98939f1a2e74b58839f8c4dab3b6b3c1ce84972ae712be02845e65391ac7c"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e519d64089b0876c7b467274468709dadf11e41d65f63bba207e04217f47c085"},
-    {file = "tornado-6.1-cp36-cp36m-win32.whl", hash = "sha256:b87936fd2c317b6ee08a5741ea06b9d11a6074ef4cc42e031bc6403f82a32575"},
-    {file = "tornado-6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:cc0ee35043162abbf717b7df924597ade8e5395e7b66d18270116f8745ceb795"},
-    {file = "tornado-6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7250a3fa399f08ec9cb3f7b1b987955d17e044f1ade821b32e5f435130250d7f"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ed3ad863b1b40cd1d4bd21e7498329ccaece75db5a5bf58cd3c9f130843e7102"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:dcef026f608f678c118779cd6591c8af6e9b4155c44e0d1bc0c87c036fb8c8c4"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:70dec29e8ac485dbf57481baee40781c63e381bebea080991893cd297742b8fd"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d3f7594930c423fd9f5d1a76bee85a2c36fd8b4b16921cae7e965f22575e9c01"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3447475585bae2e77ecb832fc0300c3695516a47d46cefa0528181a34c5b9d3d"},
-    {file = "tornado-6.1-cp37-cp37m-win32.whl", hash = "sha256:e7229e60ac41a1202444497ddde70a48d33909e484f96eb0da9baf8dc68541df"},
-    {file = "tornado-6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:cb5ec8eead331e3bb4ce8066cf06d2dfef1bfb1b2a73082dfe8a161301b76e37"},
-    {file = "tornado-6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:20241b3cb4f425e971cb0a8e4ffc9b0a861530ae3c52f2b0434e6c1b57e9fd95"},
-    {file = "tornado-6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c77da1263aa361938476f04c4b6c8916001b90b2c2fdd92d8d535e1af48fba5a"},
-    {file = "tornado-6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5"},
-    {file = "tornado-6.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:1e8225a1070cd8eec59a996c43229fe8f95689cb16e552d130b9793cb570a288"},
-    {file = "tornado-6.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d14d30e7f46a0476efb0deb5b61343b1526f73ebb5ed84f23dc794bdb88f9d9f"},
-    {file = "tornado-6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f959b26f2634a091bb42241c3ed8d3cedb506e7c27b8dd5c7b9f745318ddbb6"},
-    {file = "tornado-6.1-cp38-cp38-win32.whl", hash = "sha256:34ca2dac9e4d7afb0bed4677512e36a52f09caa6fded70b4e3e1c89dbd92c326"},
-    {file = "tornado-6.1-cp38-cp38-win_amd64.whl", hash = "sha256:6196a5c39286cc37c024cd78834fb9345e464525d8991c21e908cc046d1cc02c"},
-    {file = "tornado-6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0ba29bafd8e7e22920567ce0d232c26d4d47c8b5cf4ed7b562b5db39fa199c5"},
-    {file = "tornado-6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:33892118b165401f291070100d6d09359ca74addda679b60390b09f8ef325ffe"},
-    {file = "tornado-6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7da13da6f985aab7f6f28debab00c67ff9cbacd588e8477034c0652ac141feea"},
-    {file = "tornado-6.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:e0791ac58d91ac58f694d8d2957884df8e4e2f6687cdf367ef7eb7497f79eaa2"},
-    {file = "tornado-6.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:66324e4e1beede9ac79e60f88de548da58b1f8ab4b2f1354d8375774f997e6c0"},
-    {file = "tornado-6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a48900ecea1cbb71b8c71c620dee15b62f85f7c14189bdeee54966fbd9a0c5bd"},
-    {file = "tornado-6.1-cp39-cp39-win32.whl", hash = "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c"},
-    {file = "tornado-6.1-cp39-cp39-win_amd64.whl", hash = "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4"},
-    {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
-]
+tornado = []
 typed-ast = [
     {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
     {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
@@ -1699,22 +1658,22 @@ typeguard = [
     {file = "typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
-    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
-    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
+    {file = "virtualenv-20.16.2-py2.py3-none-any.whl", hash = "sha256:635b272a8e2f77cb051946f46c60a54ace3cb5e25568228bd6b57fc70eca9ff3"},
+    {file = "virtualenv-20.16.2.tar.gz", hash = "sha256:0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db"},
 ]
 xdoctest = [
     {file = "xdoctest-1.1.0-py3-none-any.whl", hash = "sha256:da330c4dacee51f3c785820bc743188fb6f7c64c5fa1c54bff8836b3cf23d69b"},
     {file = "xdoctest-1.1.0.tar.gz", hash = "sha256:0fd4fad7932f0a2f082dfdfb857dd6ca41603757586c39b1e5b4d333fc389f8a"},
 ]
 zipp = [
-    {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
-    {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},
+    {file = "zipp-3.10.0-py3-none-any.whl", hash = "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1"},
+    {file = "zipp-3.10.0.tar.gz", hash = "sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -646,6 +646,21 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pydantic"
+version = "1.10.2"
+description = "Data validation and settings management using python type hints"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pydocstyle"
 version = "6.1.1"
 description = "Python docstring style checker"
@@ -1107,7 +1122,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "958f5fa3c01709f6c81fce05fe9783fd547702b235711053d79759f32d9a548f"
+content-hash = "d8aa7ad2925ad28f74fb7827455af12bffdeead90143d60cc2ff895d7c7f9d0f"
 
 [metadata.files]
 alabaster = [
@@ -1405,6 +1420,44 @@ py = [
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+pydantic = [
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
+    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
+    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
+    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
+    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
+    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
+    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
+    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ pretty = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
+[[tool.mypy.overrides]]
+module = "src.*"
+ignore_missing_imports = true
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ Changelog = "https://github.com/samLozier/dbt_jinja_tests/releases"
 python = "^3.7"
 click = ">=8.0.1"
 Jinja2 = "^3.1.2"
+pydantic = "^1.10.2"
 
 [tool.poetry.dev-dependencies]
 Pygments = ">=2.10.0"

--- a/src/dbt_jinja_tests/jinja_tools/__init__.py
+++ b/src/dbt_jinja_tests/jinja_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Module that contains tools for dynamically generating dbt-tests."""

--- a/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/__init__.py
+++ b/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/__init__.py
@@ -1,0 +1,1 @@
+"""Module containing enums, dataclasses and pydantic models for dbt validation."""

--- a/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
+++ b/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
@@ -17,7 +17,7 @@ class ModelType(str, Enum):
     incremental = "incremental"
 
 
-def filepath_validator(filepath) -> Path:
+def filepath_validator(filepath: Path) -> Path:
     """Runs several tests against paths supplied from the manfiest.
 
     Is the file valid, it exists?
@@ -79,11 +79,11 @@ class DbtModel(BaseModel):
     columns: Union[None, dict[str, DbtColumn]]
 
     @validator("path")
-    def path_validate(cls, v):  # noqa
+    def path_validate(cls, v: Path) -> Path:  # noqa
         """Validate filepath."""
         return filepath_validator(v)
 
     @validator("original_file_path")
-    def original_file_path_validate(cls, v):  # noqa
+    def original_file_path_validate(cls, v: Path) -> Path:  # noqa
         """Validate OG file path."""
         return filepath_validator(v)

--- a/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
+++ b/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
@@ -68,14 +68,14 @@ class DbtModel(BaseModel):
 
     compiled: bool
     resource_type: ModelType
-    depends_on: dict  # type: ignore[type-arg]
+    depends_on: Dict  # type: ignore[type-arg]
     unique_id: str
     root_path: Path
     path: Path
     original_file_path: Path
     name: str
     alias: str
-    refs: list[Optional[list[str]]]
+    refs: List[Optional[List[str]]]
     sources: List[str]
     columns: Union[None, Dict[str, DbtColumn]]
 

--- a/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
+++ b/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
@@ -48,7 +48,7 @@ class DbtColumn(BaseModel):
 
     name: str
     description: str
-    meta: dict
+    meta: dict  # type: ignore[type-arg]
     data_type: Union[str, None]  # Optional[ColumnDatatype]
     quote: Optional[str]
 
@@ -67,7 +67,7 @@ class DbtModel(BaseModel):
 
     compiled: bool
     resource_type: ModelType
-    depends_on: dict
+    depends_on: dict  # type: ignore[type-arg]
     unique_id: str
     root_path: Path
     path: Path

--- a/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
+++ b/src/dbt_jinja_tests/jinja_tools/dbt_dataclasses/model_config.py
@@ -2,6 +2,7 @@
 from enum import Enum
 from pathlib import Path
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Union
 
@@ -75,8 +76,8 @@ class DbtModel(BaseModel):
     name: str
     alias: str
     refs: list[Optional[list[str]]]
-    sources: list[str]
-    columns: Union[None, dict[str, DbtColumn]]
+    sources: List[str]
+    columns: Union[None, Dict[str, DbtColumn]]
 
     @validator("path")
     def path_validate(cls, v: Path) -> Path:  # noqa

--- a/src/dbt_jinja_tests/jinja_tools/generation.py
+++ b/src/dbt_jinja_tests/jinja_tools/generation.py
@@ -1,5 +1,6 @@
 """Load and validate and parse a manifest.json file."""
 import json
+import typing
 from pathlib import Path
 
 from .dbt_dataclasses.model_config import DbtModel
@@ -22,8 +23,8 @@ class ManifestHandler:
         self.raw_manifest = self._read_json(self.manifest_path)
 
     @staticmethod
-    def _read_json(json_path: Path) -> dict[any]:
-        return json.loads(json_path.read_text())
+    def _read_json(json_path: Path) -> dict[str, typing.Any]:
+        return json.loads(json_path.read_text())  # type: ignore[no-any-return]
 
     def load_models(self) -> dict[str, DbtModel]:
         """Loads the manifest nodes as individual pydnatic validated models."""

--- a/src/dbt_jinja_tests/jinja_tools/generation.py
+++ b/src/dbt_jinja_tests/jinja_tools/generation.py
@@ -1,31 +1,32 @@
-from pathlib import Path
+"""Load and validate and parse a manifest.json file."""
 import json
-from .dbt_dataclasses.model_config import (
-    DbtModel,
-    DbtColumn,
-    SqlFilePath,
-    RootPath,
-    ModelType,
-)
+from pathlib import Path
+
+from .dbt_dataclasses.model_config import DbtModel
+from .dbt_dataclasses.model_config import ModelType
 
 
 class ManifestHandler:
+    """Basic class for loading, validating and parsing a manifest file."""
+
     def __int__(
         self,
         manifest_path: Path,
-    ):
+    ) -> None:
+        """Loads and validates a manifest file."""
         self.manifest_path = manifest_path
         if self.manifest_path.exists() or self.manifest_path.suffix != ".json":
             raise ValueError(
-                f"manifest_path error. Was an existing manifest.json path supplied?"
+                "manifest_path error. Was an existing manifest.json path supplied?"
             )
         self.raw_manifest = self._read_json(self.manifest_path)
 
     @staticmethod
-    def _read_json(json_path: Path) -> str:
+    def _read_json(json_path: Path) -> dict[any]:
         return json.loads(json_path.read_text())
 
-    def load_models(self) -> list[DbtModel]:
+    def load_models(self) -> dict[str, DbtModel]:
+        """Loads the manifest nodes as individual pydnatic validated models."""
         models = {}
         for node_name, node_vals in self.raw_manifest.get("nodes", {}).items():
             model = {
@@ -34,3 +35,5 @@ class ManifestHandler:
                     resource_type=ModelType(node_vals["resource_type"]),
                 )
             }
+            models.update(model)
+        return models

--- a/src/dbt_jinja_tests/jinja_tools/generation.py
+++ b/src/dbt_jinja_tests/jinja_tools/generation.py
@@ -23,10 +23,10 @@ class ManifestHandler:
         self.raw_manifest = self._read_json(self.manifest_path)
 
     @staticmethod
-    def _read_json(json_path: Path) -> dict[str, typing.Any]:
+    def _read_json(json_path: Path) -> typing.Dict[str, typing.Any]:
         return json.loads(json_path.read_text())  # type: ignore[no-any-return]
 
-    def load_models(self) -> dict[str, DbtModel]:
+    def load_models(self) -> typing.Dict[str, DbtModel]:
         """Loads the manifest nodes as individual pydnatic validated models."""
         models = {}
         for node_name, node_vals in self.raw_manifest.get("nodes", {}).items():

--- a/src/dbt_jinja_tests/jinja_tools/propogation.py
+++ b/src/dbt_jinja_tests/jinja_tools/propogation.py
@@ -1,0 +1,1 @@
+"""Module to control the various strategies for test inheretence."""

--- a/src/dbt_jinja_tests/templates/schema.yml
+++ b/src/dbt_jinja_tests/templates/schema.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: {{ model_name }}
+  - name: { { model_name } }
     config:
       enabled: true | false
       tags: <string> | [<string>]
@@ -12,8 +12,8 @@ models:
       alias: <string>
       persist_docs: <dict>
       full_refresh: <boolean>
-      meta: {<dictionary>}
-      grants: {<dictionary>}
+      meta: { { dictionary } }
+      grants: { { <dictionary> } }
     tests:
     columns:
       - name: <string>

--- a/tests/tests_jinja_tools/__init__.py
+++ b/tests/tests_jinja_tools/__init__.py
@@ -1,0 +1,1 @@
+"""A set of tools for  testing the manifest loaders."""

--- a/tests/tests_jinja_tools/conftest.py
+++ b/tests/tests_jinja_tools/conftest.py
@@ -1,18 +1,19 @@
 """Test fixtures for use with manifest.json validation."""
 import json
+import typing
 from pathlib import Path
 
 import pytest
 
 
 @pytest.fixture
-def manifest_json() -> dict[str, dict]:
+def manifest_json() -> typing.Any:
     """Loads the full manifest json from  jaffleshop for use in tests."""
     return json.loads(Path(Path(__file__).parent / "manifest.json").read_text())
 
 
 @pytest.fixture
-def single_dbt_model_json(manifest_json: dict) -> dict[str, dict]:
+def single_dbt_model_json(manifest_json: dict) -> typing.Any:  # type: ignore [type-arg]
     """Returns a single model from the broader set contained in manifest.json."""
     keys = list(manifest_json["nodes"].keys())
     return manifest_json["nodes"][keys[0]]

--- a/tests/tests_jinja_tools/conftest.py
+++ b/tests/tests_jinja_tools/conftest.py
@@ -6,13 +6,13 @@ import pytest
 
 
 @pytest.fixture
-def manifest_json() -> dict:
+def manifest_json() -> dict[str, dict]:
     """Loads the full manifest json from  jaffleshop for use in tests."""
     return json.loads(Path(Path(__file__).parent / "manifest.json").read_text())
 
 
 @pytest.fixture
-def single_dbt_model_json(manifest_json):
+def single_dbt_model_json(manifest_json: dict) -> dict[str, dict]:
     """Returns a single model from the broader set contained in manifest.json."""
     keys = list(manifest_json["nodes"].keys())
     return manifest_json["nodes"][keys[0]]

--- a/tests/tests_jinja_tools/conftest.py
+++ b/tests/tests_jinja_tools/conftest.py
@@ -1,0 +1,18 @@
+"""Test fixtures for use with manifest.json validation."""
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def manifest_json() -> dict:
+    """Loads the full manifest json from  jaffleshop for use in tests."""
+    return json.loads(Path(Path(__file__).parent / "manifest.json").read_text())
+
+
+@pytest.fixture
+def single_dbt_model_json(manifest_json):
+    """Returns a single model from the broader set contained in manifest.json."""
+    keys = list(manifest_json["nodes"].keys())
+    return manifest_json["nodes"][keys[0]]

--- a/tests/tests_jinja_tools/manifest.json
+++ b/tests/tests_jinja_tools/manifest.json
@@ -16,19 +16,14 @@
       "resource_type": "model",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "seed.jaffle_shop.raw_payments"
-        ]
+        "nodes": ["seed.jaffle_shop.raw_payments"]
       },
       "config": {
         "enabled": true,
         "alias": null,
         "schema": null,
         "database": null,
-        "tags": [
-          "staging",
-          "hourly"
-        ],
+        "tags": ["staging", "hourly"],
         "meta": {
           "owner": "@drew",
           "contains_pii": true,
@@ -49,11 +44,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "stg_payments"
-      ],
+      "fqn": ["jaffle_shop", "staging", "stg_payments"],
       "unique_id": "model.jaffle_shop.stg_payments",
       "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -67,15 +58,8 @@
         "name": "sha256",
         "checksum": "113502ed19f04efb2af0629ff139f57f7463347b6d5218f3b80a8d128cc96852"
       },
-      "tags": [
-        "staging",
-        "hourly"
-      ],
-      "refs": [
-        [
-          "raw_payments"
-        ]
-      ],
+      "tags": ["staging", "hourly"],
+      "refs": [["raw_payments"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -86,9 +70,7 @@
           "meta": {},
           "data_type": null,
           "quote": null,
-          "tags": [
-            "billing"
-          ]
+          "tags": ["billing"]
         },
         "payment_method": {
           "name": "payment_method",
@@ -113,10 +95,7 @@
       "deferred": false,
       "unrendered_config": {
         "materialized": "view",
-        "tags": [
-          "staging",
-          "hourly"
-        ]
+        "tags": ["staging", "hourly"]
       },
       "created_at": 1658917993.593117,
       "compiled_code": "with source as (\n    select * from ad_hoc.dbt_jcohen.raw_payments\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
@@ -128,22 +107,15 @@
       "compiled": true,
       "resource_type": "model",
       "depends_on": {
-        "macros": [
-          "macro.jaffle_shop.example_macro"
-        ],
-        "nodes": [
-          "seed.jaffle_shop.raw_orders"
-        ]
+        "macros": ["macro.jaffle_shop.example_macro"],
+        "nodes": ["seed.jaffle_shop.raw_orders"]
       },
       "config": {
         "enabled": true,
         "alias": null,
         "schema": null,
         "database": null,
-        "tags": [
-          "staging",
-          "hourly"
-        ],
+        "tags": ["staging", "hourly"],
         "meta": {},
         "materialized": "view",
         "incremental_strategy": null,
@@ -160,11 +132,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "stg_orders"
-      ],
+      "fqn": ["jaffle_shop", "staging", "stg_orders"],
       "unique_id": "model.jaffle_shop.stg_orders",
       "raw_code": "/*\nhack for example macro references:\n    {{ example_macro(\"abc\", \"123\") }}\n*/\n\nwith source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -178,15 +146,8 @@
         "name": "sha256",
         "checksum": "5a2807569bc8d9b74f7ffecfbf12d1e3b6dfbc6cbff66dd38ce20306532b6f77"
       },
-      "tags": [
-        "staging",
-        "hourly"
-      ],
-      "refs": [
-        [
-          "raw_orders"
-        ]
-      ],
+      "tags": ["staging", "hourly"],
+      "refs": [["raw_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -218,10 +179,7 @@
       "deferred": false,
       "unrendered_config": {
         "materialized": "view",
-        "tags": [
-          "staging",
-          "hourly"
-        ]
+        "tags": ["staging", "hourly"]
       },
       "created_at": 1658917993.59104,
       "compiled_code": "/*\nhack for example macro references:\n    \n\n    The provided args are abc and 123\n\n\n*/\n\nwith source as (\n    select * from ad_hoc.dbt_jcohen.raw_orders\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
@@ -244,10 +202,7 @@
         "alias": null,
         "schema": null,
         "database": null,
-        "tags": [
-          "staging",
-          "hourly"
-        ],
+        "tags": ["staging", "hourly"],
         "meta": {},
         "materialized": "view",
         "incremental_strategy": null,
@@ -264,11 +219,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "hidden_model"
-      ],
+      "fqn": ["jaffle_shop", "staging", "hidden_model"],
       "unique_id": "model.jaffle_shop.hidden_model",
       "raw_code": "-- hack for DAG viz\n-- {{ source('payments', 'orders') }}\n\nselect * from {{ ref('stg_orders') }}",
       "language": "sql",
@@ -282,21 +233,9 @@
         "name": "sha256",
         "checksum": "ab09cc6daa39542203d5cbba28e07b823193bf0ce81a86f88a7f705b71fffda5"
       },
-      "tags": [
-        "staging",
-        "hourly"
-      ],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
-      "sources": [
-        [
-          "payments",
-          "orders"
-        ]
-      ],
+      "tags": ["staging", "hourly"],
+      "refs": [["stg_orders"]],
+      "sources": [["payments", "orders"]],
       "metrics": [],
       "description": "",
       "columns": {},
@@ -310,10 +249,7 @@
       "deferred": false,
       "unrendered_config": {
         "materialized": "view",
-        "tags": [
-          "staging",
-          "hourly"
-        ]
+        "tags": ["staging", "hourly"]
       },
       "created_at": 1658917993.593442,
       "compiled_code": "-- hack for DAG viz\n-- ad_hoc.dbt_jcohen.raw_orders\n\nselect * from ad_hoc.dbt_jcohen.stg_orders",
@@ -353,12 +289,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "marts",
-        "core",
-        "fct_orders"
-      ],
+      "fqn": ["jaffle_shop", "marts", "core", "fct_orders"],
       "unique_id": "model.jaffle_shop.fct_orders",
       "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\norder_payments as (\n\n    select * from {{ ref('order_payments') }}\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{payment_method}}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
       "language": "sql",
@@ -373,14 +304,7 @@
         "checksum": "49634cca4e40171ea98f62a1a3a9999e3487c42aca3ee79ecaaf99900ead1fd8"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ],
-        [
-          "order_payments"
-        ]
-      ],
+      "refs": [["stg_orders"], ["order_payments"]],
       "sources": [],
       "metrics": [],
       "description": "This table has basic information about orders, as well as some derived facts based on payments",
@@ -485,9 +409,7 @@
       "resource_type": "model",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.stg_payments"
-        ]
+        "nodes": ["model.jaffle_shop.stg_payments"]
       },
       "config": {
         "enabled": true,
@@ -511,13 +433,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "marts",
-        "core",
-        "intermediate",
-        "order_payments"
-      ],
+      "fqn": ["jaffle_shop", "marts", "core", "intermediate", "order_payments"],
       "unique_id": "model.jaffle_shop.order_payments",
       "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith payments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\nfinal as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{payment_method}}' then amount else 0 end) as {{payment_method}}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n)\n\nselect * from final",
       "language": "sql",
@@ -532,11 +448,7 @@
         "checksum": "6af89b1b7d0e9fe6b2b54118cf2addf0bab34ccc49b054eab93f8d7056fb7c52"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_payments"
-        ]
-      ],
+      "refs": [["stg_payments"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -611,14 +523,7 @@
         "checksum": "feb9a66904fe7968464b947a2289c795d58fbc7f1e14a3c9975dc261d94cb351"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_payments"
-        ],
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_payments"], ["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -645,9 +550,7 @@
       "resource_type": "model",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.stg_orders"
-        ]
+        "nodes": ["model.jaffle_shop.stg_orders"]
       },
       "config": {
         "enabled": true,
@@ -692,11 +595,7 @@
         "checksum": "20c96fcb3cf2235582de807d64cd1cdbdd3a419786bf1ceaae0ef208e7ed3dd7"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -722,12 +621,8 @@
       "compiled": true,
       "resource_type": "model",
       "depends_on": {
-        "macros": [
-          "macro.dbt.py_script_postfix"
-        ],
-        "nodes": [
-          "model.jaffle_shop.stg_orders"
-        ]
+        "macros": ["macro.dbt.py_script_postfix"],
+        "nodes": ["model.jaffle_shop.stg_orders"]
       },
       "config": {
         "enabled": true,
@@ -745,21 +640,13 @@
         "unique_key": null,
         "on_schema_change": "ignore",
         "grants": {},
-        "packages": [
-          "holidays"
-        ],
+        "packages": ["holidays"],
         "post-hook": [],
         "pre-hook": []
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "marts",
-        "core",
-        "intermediate",
-        "holiday_orders"
-      ],
+      "fqn": ["jaffle_shop", "marts", "core", "intermediate", "holiday_orders"],
       "unique_id": "model.jaffle_shop.holiday_orders",
       "raw_code": "import holidays\n\ndef is_holiday(date_col):\n    # Chez Jaffle\n    french_holidays = holidays.France()\n    is_holiday = (date_col in french_holidays)\n    return is_holiday\n\ndef model(dbt, session):\n    dbt.config(\n        materialized = \"table\",\n        packages = [\"holidays\"]\n    )\n    \n    orders_df = dbt.ref(\"stg_orders\")\n    df = orders_df.to_pandas()\n    df[\"IS_HOLIDAY\"] = df[\"ORDER_DATE\"].apply(is_holiday)\n    return df",
       "language": "python",
@@ -774,11 +661,7 @@
         "checksum": "448dac79699fbcf21faee19cae2c48bb4f6367430d86f79ca7885af91286b774"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -793,9 +676,7 @@
       "deferred": false,
       "unrendered_config": {
         "materialized": "table",
-        "packages": [
-          "holidays"
-        ]
+        "packages": ["holidays"]
       },
       "created_at": 1658917993.47931,
       "compiled_code": "import holidays\n\ndef is_holiday(date_col):\n    # Chez Jaffle\n    french_holidays = holidays.France()\n    is_holiday = (date_col in french_holidays)\n    return is_holiday\n\ndef model(dbt, session):\n    dbt.config(\n        materialized = \"table\",\n        packages = [\"holidays\"]\n    )\n    \n    orders_df = dbt.ref(\"stg_orders\")\n    df = orders_df.to_pandas()\n    df[\"IS_HOLIDAY\"] = df[\"ORDER_DATE\"].apply(is_holiday)\n    return df\n\n\n# This part is user provided model code\n# you will need to copy the next section to run the code\n# COMMAND ----------\n# this part is dbt logic for get ref work, do not modify\n\ndef ref(*args,dbt_load_df_function):\n    refs = {\"stg_orders\": \"ad_hoc.dbt_jcohen.stg_orders\"}\n    key = \".\".join(args)\n    return dbt_load_df_function(refs[key])\n\n\ndef source(*args, dbt_load_df_function):\n    sources = {}\n    key = \".\".join(args)\n    return dbt_load_df_function(sources[key])\n\n\nconfig_dict = {}\n\n\nclass config:\n    def __init__(self, *args, **kwargs):\n        pass\n\n    @staticmethod\n    def get(key):\n        return config_dict.get(key)\n\nclass this:\n    \"\"\"dbt.this() or dbt.this.identifier\"\"\"\n    database = 'ad_hoc'\n    schema = 'dbt_jcohen'\n    identifier = 'holiday_orders'\n    def __repr__(self):\n        return 'ad_hoc.dbt_jcohen.holiday_orders'\n\n\nclass dbtObj:\n    def __init__(self, load_df_function) -> None:\n        self.source = lambda x: source(x, dbt_load_df_function=load_df_function)\n        self.ref = lambda x: ref(x, dbt_load_df_function=load_df_function)\n        self.config = config\n        self.this = this()\n        self.is_incremental = False\n\n\n# COMMAND ----------\n\n",
@@ -808,9 +689,7 @@
       "resource_type": "analysis",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.stg_orders"
-        ]
+        "nodes": ["model.jaffle_shop.stg_orders"]
       },
       "config": {
         "enabled": true,
@@ -834,11 +713,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "analysis",
-        "my_analysis"
-      ],
+      "fqn": ["jaffle_shop", "analysis", "my_analysis"],
       "unique_id": "analysis.jaffle_shop.my_analysis",
       "raw_code": "select\n\n  customer_id,\n  count(is_holiday) as number_of_holiday_orders\n\nfrom {{ ref('stg_orders') }}\ngroup by 1",
       "language": "sql",
@@ -853,11 +728,7 @@
         "checksum": "60aba7b1126f4fb7f81da9ed23aff2a5062682015907bd92fe118692b1e635d7"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "Here are the docs for my really cool analysis",
@@ -884,9 +755,7 @@
       "resource_type": "test",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.stg_orders"
-        ]
+        "nodes": ["model.jaffle_shop.stg_orders"]
       },
       "config": {
         "enabled": true,
@@ -906,10 +775,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "example_data_test"
-      ],
+      "fqn": ["jaffle_shop", "example_data_test"],
       "unique_id": "test.jaffle_shop.example_data_test",
       "raw_code": "select * from {{ ref('stg_orders') }}",
       "language": "sql",
@@ -924,11 +790,7 @@
         "checksum": "b68d2666d3502ec95f54174a518b6d43ee67fac443bf1a66746863f00f053f3b"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -953,18 +815,14 @@
       "resource_type": "test",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.stg_customers"
-        ]
+        "nodes": ["model.jaffle_shop.stg_customers"]
       },
       "config": {
         "enabled": true,
         "alias": null,
         "schema": "dbt_test__audit",
         "database": null,
-        "tags": [
-          "important"
-        ],
+        "tags": ["important"],
         "meta": {},
         "materialized": "test",
         "severity": "ERROR",
@@ -977,10 +835,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "tagged_data_test"
-      ],
+      "fqn": ["jaffle_shop", "tagged_data_test"],
       "unique_id": "test.jaffle_shop.tagged_data_test",
       "raw_code": "{{ config(tags = ['important']) }}\n\nselect * from {{ ref('stg_customers') }}",
       "language": "sql",
@@ -994,14 +849,8 @@
         "name": "sha256",
         "checksum": "c1b1411e66ba999f60ac8248f393f9b2f42a0caf111133efa87cec26131fdbc6"
       },
-      "tags": [
-        "important"
-      ],
-      "refs": [
-        [
-          "stg_customers"
-        ]
-      ],
+      "tags": ["important"],
+      "refs": [["stg_customers"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1015,9 +864,7 @@
       "build_path": null,
       "deferred": false,
       "unrendered_config": {
-        "tags": [
-          "important"
-        ]
+        "tags": ["important"]
       },
       "created_at": 1658917993.546377,
       "compiled_code": "\n\nselect * from ad_hoc.dbt_jcohen.stg_customers",
@@ -1055,10 +902,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "raw_orders"
-      ],
+      "fqn": ["jaffle_shop", "raw_orders"],
       "unique_id": "seed.jaffle_shop.raw_orders",
       "raw_code": "",
       "language": "sql",
@@ -1123,10 +967,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "raw_payments"
-      ],
+      "fqn": ["jaffle_shop", "raw_payments"],
       "unique_id": "seed.jaffle_shop.raw_payments",
       "raw_code": "",
       "language": "sql",
@@ -1173,13 +1014,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_unique",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.stg_orders"
-        ]
+        "macros": ["macro.dbt.test_unique", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.stg_orders"]
       },
       "config": {
         "enabled": true,
@@ -1199,11 +1035,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "unique_stg_orders_order_id"
-      ],
+      "fqn": ["jaffle_shop", "staging", "unique_stg_orders_order_id"],
       "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1218,11 +1050,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1256,13 +1084,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.stg_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.stg_orders"]
       },
       "config": {
         "enabled": true,
@@ -1282,11 +1105,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "not_null_stg_orders_order_id"
-      ],
+      "fqn": ["jaffle_shop", "staging", "not_null_stg_orders_order_id"],
       "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1301,11 +1120,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1350,9 +1165,7 @@
           "macro.dbt.test_accepted_values",
           "macro.dbt.get_where_subquery"
         ],
-        "nodes": [
-          "model.jaffle_shop.stg_orders"
-        ]
+        "nodes": ["model.jaffle_shop.stg_orders"]
       },
       "config": {
         "enabled": true,
@@ -1391,11 +1204,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_orders"
-        ]
-      ],
+      "refs": [["stg_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1431,13 +1240,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_unique",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.stg_payments"
-        ]
+        "macros": ["macro.dbt.test_unique", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.stg_payments"]
       },
       "config": {
         "enabled": true,
@@ -1457,11 +1261,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "unique_stg_payments_payment_id"
-      ],
+      "fqn": ["jaffle_shop", "staging", "unique_stg_payments_payment_id"],
       "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1475,14 +1275,8 @@
         "name": "none",
         "checksum": ""
       },
-      "tags": [
-        "billing"
-      ],
-      "refs": [
-        [
-          "stg_payments"
-        ]
-      ],
+      "tags": ["billing"],
+      "refs": [["stg_payments"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1516,13 +1310,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.stg_payments"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.stg_payments"]
       },
       "config": {
         "enabled": true,
@@ -1542,11 +1331,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "not_null_stg_payments_payment_id"
-      ],
+      "fqn": ["jaffle_shop", "staging", "not_null_stg_payments_payment_id"],
       "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1560,14 +1345,8 @@
         "name": "none",
         "checksum": ""
       },
-      "tags": [
-        "billing"
-      ],
-      "refs": [
-        [
-          "stg_payments"
-        ]
-      ],
+      "tags": ["billing"],
+      "refs": [["stg_payments"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1593,12 +1372,7 @@
       "test_metadata": {
         "name": "accepted_values",
         "kwargs": {
-          "values": [
-            "credit_card",
-            "coupon",
-            "bank_transfer",
-            "gift_card"
-          ],
+          "values": ["credit_card", "coupon", "bank_transfer", "gift_card"],
           "column_name": "payment_method",
           "model": "{{ get_where_subquery(ref('stg_payments')) }}"
         },
@@ -1611,9 +1385,7 @@
           "macro.dbt.test_accepted_values",
           "macro.dbt.get_where_subquery"
         ],
-        "nodes": [
-          "model.jaffle_shop.stg_payments"
-        ]
+        "nodes": ["model.jaffle_shop.stg_payments"]
       },
       "config": {
         "enabled": true,
@@ -1652,11 +1424,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_payments"
-        ]
-      ],
+      "refs": [["stg_payments"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1692,13 +1460,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_unique",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_unique", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -1718,12 +1481,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "marts",
-        "core",
-        "unique_fct_orders_order_id"
-      ],
+      "fqn": ["jaffle_shop", "marts", "core", "unique_fct_orders_order_id"],
       "unique_id": "test.jaffle_shop.unique_fct_orders_order_id.523ddb6ce5",
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1738,11 +1496,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1776,13 +1530,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -1802,12 +1551,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "marts",
-        "core",
-        "not_null_fct_orders_order_id"
-      ],
+      "fqn": ["jaffle_shop", "marts", "core", "not_null_fct_orders_order_id"],
       "unique_id": "test.jaffle_shop.not_null_fct_orders_order_id.4e687af8d0",
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1822,11 +1566,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1860,13 +1600,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -1906,11 +1641,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -1993,14 +1724,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "dim_customers"
-        ],
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["dim_customers"], ["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2042,9 +1766,7 @@
           "macro.dbt.test_relationships",
           "macro.dbt.get_where_subquery"
         ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -2084,11 +1806,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2135,9 +1853,7 @@
           "macro.dbt.test_accepted_values",
           "macro.dbt.get_where_subquery"
         ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -2177,11 +1893,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2217,13 +1929,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -2243,12 +1950,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "marts",
-        "core",
-        "not_null_fct_orders_amount"
-      ],
+      "fqn": ["jaffle_shop", "marts", "core", "not_null_fct_orders_amount"],
       "unique_id": "test.jaffle_shop.not_null_fct_orders_amount.66810a8d08",
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2263,11 +1965,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2301,13 +1999,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -2347,11 +2040,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2385,13 +2074,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -2431,11 +2115,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2469,13 +2149,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -2515,11 +2190,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2553,13 +2224,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
       "config": {
         "enabled": true,
@@ -2599,11 +2265,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2658,12 +2320,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "marts",
-        "core",
-        "dim_customers"
-      ],
+      "fqn": ["jaffle_shop", "marts", "core", "dim_customers"],
       "unique_id": "model.jaffle_shop.dim_customers",
       "raw_code": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\ncustomer_orders as (\n\n    select * from {{ ref('customer_orders') }}\n\n),\n\ncustomer_payments as (\n\n    select * from {{ ref('customer_payments') }}\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final",
       "language": "sql",
@@ -2678,17 +2335,7 @@
         "checksum": "95d544c0e900d9ac69d0471bad24e03c63a268dbc493559023b58b7618c49b3a"
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_customers"
-        ],
-        [
-          "customer_orders"
-        ],
-        [
-          "customer_payments"
-        ]
-      ],
+      "refs": [["stg_customers"], ["customer_orders"], ["customer_payments"]],
       "sources": [],
       "metrics": [],
       "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
@@ -2789,19 +2436,14 @@
       "resource_type": "model",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "seed.jaffle_shop.raw_customers"
-        ]
+        "nodes": ["seed.jaffle_shop.raw_customers"]
       },
       "config": {
         "enabled": true,
         "alias": null,
         "schema": null,
         "database": null,
-        "tags": [
-          "staging",
-          "hourly"
-        ],
+        "tags": ["staging", "hourly"],
         "meta": {},
         "materialized": "view",
         "incremental_strategy": null,
@@ -2818,11 +2460,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "stg_customers"
-      ],
+      "fqn": ["jaffle_shop", "staging", "stg_customers"],
       "unique_id": "model.jaffle_shop.stg_customers",
       "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name,\n        email\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -2836,15 +2474,8 @@
         "name": "sha256",
         "checksum": "8aaf3f82d6948a706a8fd6e40493a59446ab84436c800b9bb986d6af6d3dc073"
       },
-      "tags": [
-        "staging",
-        "hourly"
-      ],
-      "refs": [
-        [
-          "raw_customers"
-        ]
-      ],
+      "tags": ["staging", "hourly"],
+      "refs": [["raw_customers"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -2868,10 +2499,7 @@
       "deferred": false,
       "unrendered_config": {
         "materialized": "view",
-        "tags": [
-          "staging",
-          "hourly"
-        ]
+        "tags": ["staging", "hourly"]
       },
       "created_at": 1658918611.0494258,
       "compiled_code": "with source as (\n    select * from ad_hoc.dbt_jcohen.raw_customers\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name,\n        email\n\n    from source\n\n)\n\nselect * from renamed",
@@ -2909,10 +2537,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
-      "fqn": [
-        "jaffle_shop",
-        "raw_customers"
-      ],
+      "fqn": ["jaffle_shop", "raw_customers"],
       "unique_id": "seed.jaffle_shop.raw_customers",
       "raw_code": "",
       "language": "sql",
@@ -2959,13 +2584,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_unique",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.dim_customers"
-        ]
+        "macros": ["macro.dbt.test_unique", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.dim_customers"]
       },
       "config": {
         "enabled": true,
@@ -3005,11 +2625,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "dim_customers"
-        ]
-      ],
+      "refs": [["dim_customers"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -3043,13 +2659,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.dim_customers"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.dim_customers"]
       },
       "config": {
         "enabled": true,
@@ -3089,11 +2700,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "dim_customers"
-        ]
-      ],
+      "refs": [["dim_customers"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -3127,13 +2734,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_unique",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.stg_customers"
-        ]
+        "macros": ["macro.dbt.test_unique", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.stg_customers"]
       },
       "config": {
         "enabled": true,
@@ -3153,11 +2755,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "unique_stg_customers_customer_id"
-      ],
+      "fqn": ["jaffle_shop", "staging", "unique_stg_customers_customer_id"],
       "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -3172,11 +2770,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_customers"
-        ]
-      ],
+      "refs": [["stg_customers"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -3210,13 +2804,8 @@
       "compiled": true,
       "resource_type": "test",
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null",
-          "macro.dbt.get_where_subquery"
-        ],
-        "nodes": [
-          "model.jaffle_shop.stg_customers"
-        ]
+        "macros": ["macro.dbt.test_not_null", "macro.dbt.get_where_subquery"],
+        "nodes": ["model.jaffle_shop.stg_customers"]
       },
       "config": {
         "enabled": true,
@@ -3236,11 +2825,7 @@
       },
       "database": "ad_hoc",
       "schema": "dbt_jcohen_dbt_test__audit",
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "not_null_stg_customers_customer_id"
-      ],
+      "fqn": ["jaffle_shop", "staging", "not_null_stg_customers_customer_id"],
       "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -3255,11 +2840,7 @@
         "checksum": ""
       },
       "tags": [],
-      "refs": [
-        [
-          "stg_customers"
-        ]
-      ],
+      "refs": [["stg_customers"]],
       "sources": [],
       "metrics": [],
       "description": "",
@@ -3284,12 +2865,7 @@
   },
   "sources": {
     "source.jaffle_shop.payments.orders": {
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "payments",
-        "orders"
-      ],
+      "fqn": ["jaffle_shop", "staging", "payments", "orders"],
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
       "unique_id": "source.jaffle_shop.payments.orders",
@@ -3336,12 +2912,7 @@
       "created_at": 1658917993.6548522
     },
     "source.jaffle_shop.payments.tagged_source": {
-      "fqn": [
-        "jaffle_shop",
-        "staging",
-        "payments",
-        "tagged_source"
-      ],
+      "fqn": ["jaffle_shop", "staging", "payments", "tagged_source"],
       "database": "ad_hoc",
       "schema": "dbt_jcohen",
       "unique_id": "source.jaffle_shop.payments.tagged_source",
@@ -3378,9 +2949,7 @@
       "columns": {},
       "meta": {},
       "source_meta": {},
-      "tags": [
-        "important"
-      ],
+      "tags": ["important"],
       "config": {
         "enabled": true
       },
@@ -3435,9 +3004,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -3459,9 +3026,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.py_write_table"
-        ]
+        "macros": ["macro.dbt_snowflake.py_write_table"]
       },
       "description": "",
       "meta": {},
@@ -3505,9 +3070,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.get_column_comment_sql"
-        ]
+        "macros": ["macro.dbt_snowflake.get_column_comment_sql"]
       },
       "description": "",
       "meta": {},
@@ -3554,9 +3117,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -3578,9 +3139,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -3602,9 +3161,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -3626,9 +3183,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -3694,9 +3249,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.current_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.current_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -3718,9 +3271,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -3742,9 +3293,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -3788,9 +3337,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.get_column_comment_sql"
-        ]
+        "macros": ["macro.dbt_snowflake.get_column_comment_sql"]
       },
       "description": "",
       "meta": {},
@@ -3812,9 +3359,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -3836,9 +3381,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__set_query_tag"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__set_query_tag"]
       },
       "description": "",
       "meta": {},
@@ -3885,9 +3428,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__unset_query_tag"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__unset_query_tag"]
       },
       "description": "",
       "meta": {},
@@ -3909,9 +3450,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -3933,9 +3472,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -4292,9 +3829,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_incremental_merge_sql"
-        ]
+        "macros": ["macro.dbt.get_incremental_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -4430,9 +3965,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -4476,9 +4009,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.make_hook_config"
-        ]
+        "macros": ["macro.dbt.make_hook_config"]
       },
       "description": "",
       "meta": {},
@@ -4500,9 +4031,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.make_hook_config"
-        ]
+        "macros": ["macro.dbt.make_hook_config"]
       },
       "description": "",
       "meta": {},
@@ -4524,9 +4053,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.make_hook_config"
-        ]
+        "macros": ["macro.dbt.make_hook_config"]
       },
       "description": "",
       "meta": {},
@@ -4614,9 +4141,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__snapshot_merge_sql"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__snapshot_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -4682,9 +4207,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__snapshot_hash_arguments"
-        ]
+        "macros": ["macro.dbt.default__snapshot_hash_arguments"]
       },
       "description": "",
       "meta": {},
@@ -4728,9 +4251,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__snapshot_get_time"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__snapshot_get_time"]
       },
       "description": "",
       "meta": {},
@@ -4752,9 +4273,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.current_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.current_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -4776,9 +4295,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.snapshot_hash_arguments"
-        ]
+        "macros": ["macro.dbt.snapshot_hash_arguments"]
       },
       "description": "",
       "meta": {},
@@ -4800,9 +4317,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__snapshot_string_as_time"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__snapshot_string_as_time"]
       },
       "description": "",
       "meta": {},
@@ -4846,9 +4361,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_columns_in_query"
-        ]
+        "macros": ["macro.dbt.get_columns_in_query"]
       },
       "description": "",
       "meta": {},
@@ -4897,9 +4410,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__create_columns"
-        ]
+        "macros": ["macro.dbt.default__create_columns"]
       },
       "description": "",
       "meta": {},
@@ -4921,9 +4432,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -4945,9 +4454,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__post_snapshot"
-        ]
+        "macros": ["macro.dbt.default__post_snapshot"]
       },
       "description": "",
       "meta": {},
@@ -4991,9 +4498,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_true_sql"
-        ]
+        "macros": ["macro.dbt.default__get_true_sql"]
       },
       "description": "",
       "meta": {},
@@ -5037,9 +4542,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__snapshot_staging_table"
-        ]
+        "macros": ["macro.dbt.default__snapshot_staging_table"]
       },
       "description": "",
       "meta": {},
@@ -5061,9 +4564,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.snapshot_get_time"
-        ]
+        "macros": ["macro.dbt.snapshot_get_time"]
       },
       "description": "",
       "meta": {},
@@ -5085,9 +4586,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__build_snapshot_table"
-        ]
+        "macros": ["macro.dbt.default__build_snapshot_table"]
       },
       "description": "",
       "meta": {},
@@ -5222,9 +4721,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_test_sql"
-        ]
+        "macros": ["macro.dbt.default__get_test_sql"]
       },
       "description": "",
       "meta": {},
@@ -5268,9 +4765,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_where_subquery"
-        ]
+        "macros": ["macro.dbt.default__get_where_subquery"]
       },
       "description": "",
       "meta": {},
@@ -5380,9 +4875,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__get_merge_sql"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__get_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -5404,9 +4897,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_quoted_csv"
-        ]
+        "macros": ["macro.dbt.get_quoted_csv"]
       },
       "description": "",
       "meta": {},
@@ -5428,9 +4919,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__get_delete_insert_merge_sql"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__get_delete_insert_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -5452,9 +4941,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_quoted_csv"
-        ]
+        "macros": ["macro.dbt.get_quoted_csv"]
       },
       "description": "",
       "meta": {},
@@ -5476,9 +4963,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_insert_overwrite_merge_sql"
-        ]
+        "macros": ["macro.dbt.default__get_insert_overwrite_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -5500,9 +4985,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_quoted_csv"
-        ]
+        "macros": ["macro.dbt.get_quoted_csv"]
       },
       "description": "",
       "meta": {},
@@ -5524,9 +5007,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.should_full_refresh"
-        ]
+        "macros": ["macro.dbt.should_full_refresh"]
       },
       "description": "",
       "meta": {},
@@ -5548,9 +5029,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_incremental_append_sql"
-        ]
+        "macros": ["macro.dbt.default__get_incremental_append_sql"]
       },
       "description": "",
       "meta": {},
@@ -5572,9 +5051,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_insert_into_sql"
-        ]
+        "macros": ["macro.dbt.get_insert_into_sql"]
       },
       "description": "",
       "meta": {},
@@ -5596,9 +5073,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_incremental_delete_insert_sql"
-        ]
+        "macros": ["macro.dbt.default__get_incremental_delete_insert_sql"]
       },
       "description": "",
       "meta": {},
@@ -5620,9 +5095,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_delete_insert_merge_sql"
-        ]
+        "macros": ["macro.dbt.get_delete_insert_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -5644,9 +5117,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_incremental_merge_sql"
-        ]
+        "macros": ["macro.dbt.default__get_incremental_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -5668,9 +5139,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_merge_sql"
-        ]
+        "macros": ["macro.dbt.get_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -5692,9 +5161,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_incremental_insert_overwrite_sql"
-        ]
+        "macros": ["macro.dbt.default__get_incremental_insert_overwrite_sql"]
       },
       "description": "",
       "meta": {},
@@ -5716,9 +5183,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_insert_overwrite_merge_sql"
-        ]
+        "macros": ["macro.dbt.get_insert_overwrite_merge_sql"]
       },
       "description": "",
       "meta": {},
@@ -5740,9 +5205,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__get_incremental_default_sql"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__get_incremental_default_sql"]
       },
       "description": "",
       "meta": {},
@@ -5764,9 +5227,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_incremental_append_sql"
-        ]
+        "macros": ["macro.dbt.get_incremental_append_sql"]
       },
       "description": "",
       "meta": {},
@@ -5788,9 +5249,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_quoted_csv"
-        ]
+        "macros": ["macro.dbt.get_quoted_csv"]
       },
       "description": "",
       "meta": {},
@@ -5873,10 +5332,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.diff_columns",
-          "macro.dbt.diff_column_data_types"
-        ]
+        "macros": ["macro.dbt.diff_columns", "macro.dbt.diff_column_data_types"]
       },
       "description": "",
       "meta": {},
@@ -5982,9 +5438,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_create_table_as_sql"
-        ]
+        "macros": ["macro.dbt.default__get_create_table_as_sql"]
       },
       "description": "",
       "meta": {},
@@ -6006,9 +5460,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.create_table_as"
-        ]
+        "macros": ["macro.dbt.create_table_as"]
       },
       "description": "",
       "meta": {},
@@ -6030,9 +5482,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__create_table_as"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__create_table_as"]
       },
       "description": "",
       "meta": {},
@@ -6109,9 +5559,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__handle_existing_table"
-        ]
+        "macros": ["macro.dbt.default__handle_existing_table"]
       },
       "description": "",
       "meta": {},
@@ -6185,9 +5633,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_create_view_as_sql"
-        ]
+        "macros": ["macro.dbt.default__get_create_view_as_sql"]
       },
       "description": "",
       "meta": {},
@@ -6209,9 +5655,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.create_view_as"
-        ]
+        "macros": ["macro.dbt.create_view_as"]
       },
       "description": "",
       "meta": {},
@@ -6233,9 +5677,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__create_view_as"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__create_view_as"]
       },
       "description": "",
       "meta": {},
@@ -6313,9 +5755,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__create_csv_table"
-        ]
+        "macros": ["macro.dbt.default__create_csv_table"]
       },
       "description": "",
       "meta": {},
@@ -6337,9 +5777,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -6361,9 +5799,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__reset_csv_table"
-        ]
+        "macros": ["macro.dbt.default__reset_csv_table"]
       },
       "description": "",
       "meta": {},
@@ -6385,9 +5821,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.create_csv_table"
-        ]
+        "macros": ["macro.dbt.create_csv_table"]
       },
       "description": "",
       "meta": {},
@@ -6409,9 +5843,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_csv_sql"
-        ]
+        "macros": ["macro.dbt.default__get_csv_sql"]
       },
       "description": "",
       "meta": {},
@@ -6455,9 +5887,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_binding_char"
-        ]
+        "macros": ["macro.dbt.default__get_binding_char"]
       },
       "description": "",
       "meta": {},
@@ -6501,9 +5931,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_batch_size"
-        ]
+        "macros": ["macro.dbt.default__get_batch_size"]
       },
       "description": "",
       "meta": {},
@@ -6569,9 +5997,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__load_csv_rows"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__load_csv_rows"]
       },
       "description": "",
       "meta": {},
@@ -6619,9 +6045,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__generate_alias_name"
-        ]
+        "macros": ["macro.dbt.default__generate_alias_name"]
       },
       "description": "",
       "meta": {},
@@ -6665,9 +6089,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__generate_schema_name"
-        ]
+        "macros": ["macro.dbt.default__generate_schema_name"]
       },
       "description": "",
       "meta": {},
@@ -6733,9 +6155,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__generate_database_name"
-        ]
+        "macros": ["macro.dbt.default__generate_database_name"]
       },
       "description": "",
       "meta": {},
@@ -6801,9 +6221,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.should_store_failures"
-        ]
+        "macros": ["macro.dbt.should_store_failures"]
       },
       "description": "",
       "meta": {},
@@ -6913,9 +6331,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -6959,9 +6375,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.convert_datetime"
-        ]
+        "macros": ["macro.dbt.convert_datetime"]
       },
       "description": "",
       "meta": {},
@@ -6983,9 +6397,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.dates_in_range"
-        ]
+        "macros": ["macro.dbt.dates_in_range"]
       },
       "description": "",
       "meta": {},
@@ -7029,9 +6441,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__except"
-        ]
+        "macros": ["macro.dbt_utils.default__except"]
       },
       "description": "",
       "meta": {},
@@ -7075,9 +6485,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__replace"
-        ]
+        "macros": ["macro.dbt_utils.default__replace"]
       },
       "description": "",
       "meta": {},
@@ -7121,9 +6529,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__concat"
-        ]
+        "macros": ["macro.dbt_utils.default__concat"]
       },
       "description": "",
       "meta": {},
@@ -7167,9 +6573,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__length"
-        ]
+        "macros": ["macro.dbt_utils.default__length"]
       },
       "description": "",
       "meta": {},
@@ -7213,9 +6617,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__dateadd"
-        ]
+        "macros": ["macro.dbt_utils.default__dateadd"]
       },
       "description": "",
       "meta": {},
@@ -7259,9 +6661,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__intersect"
-        ]
+        "macros": ["macro.dbt_utils.default__intersect"]
       },
       "description": "",
       "meta": {},
@@ -7305,9 +6705,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__escape_single_quotes"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__escape_single_quotes"]
       },
       "description": "",
       "meta": {},
@@ -7351,9 +6749,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__right"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__right"]
       },
       "description": "",
       "meta": {},
@@ -7397,9 +6793,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__listagg"
-        ]
+        "macros": ["macro.dbt.default__listagg"]
       },
       "description": "",
       "meta": {},
@@ -7443,9 +6837,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__datediff"
-        ]
+        "macros": ["macro.dbt_utils.default__datediff"]
       },
       "description": "",
       "meta": {},
@@ -7489,9 +6881,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__safe_cast"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__safe_cast"]
       },
       "description": "",
       "meta": {},
@@ -7535,9 +6925,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__hash"
-        ]
+        "macros": ["macro.dbt_utils.default__hash"]
       },
       "description": "",
       "meta": {},
@@ -7581,9 +6969,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__cast_bool_to_text"
-        ]
+        "macros": ["macro.dbt_utils.default__cast_bool_to_text"]
       },
       "description": "",
       "meta": {},
@@ -7627,9 +7013,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__any_value"
-        ]
+        "macros": ["macro.dbt.default__any_value"]
       },
       "description": "",
       "meta": {},
@@ -7673,9 +7057,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__position"
-        ]
+        "macros": ["macro.dbt_utils.default__position"]
       },
       "description": "",
       "meta": {},
@@ -7719,9 +7101,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__string_literal"
-        ]
+        "macros": ["macro.dbt_utils.default__string_literal"]
       },
       "description": "",
       "meta": {},
@@ -7765,9 +7145,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_string"
-        ]
+        "macros": ["macro.dbt_utils.default__type_string"]
       },
       "description": "",
       "meta": {},
@@ -7811,9 +7189,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.default__type_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -7857,9 +7233,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_float"
-        ]
+        "macros": ["macro.dbt_utils.default__type_float"]
       },
       "description": "",
       "meta": {},
@@ -7903,9 +7277,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_numeric"
-        ]
+        "macros": ["macro.dbt_utils.default__type_numeric"]
       },
       "description": "",
       "meta": {},
@@ -7949,9 +7321,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_bigint"
-        ]
+        "macros": ["macro.dbt_utils.default__type_bigint"]
       },
       "description": "",
       "meta": {},
@@ -7995,9 +7365,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_int"
-        ]
+        "macros": ["macro.dbt_utils.default__type_int"]
       },
       "description": "",
       "meta": {},
@@ -8041,9 +7409,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__bool_or"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__bool_or"]
       },
       "description": "",
       "meta": {},
@@ -8087,9 +7453,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__last_day"
-        ]
+        "macros": ["macro.dbt_utils.default__last_day"]
       },
       "description": "",
       "meta": {},
@@ -8111,10 +7475,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.dateadd",
-          "macro.dbt_utils.date_trunc"
-        ]
+        "macros": ["macro.dbt_utils.dateadd", "macro.dbt_utils.date_trunc"]
       },
       "description": "",
       "meta": {},
@@ -8136,9 +7497,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default_last_day"
-        ]
+        "macros": ["macro.dbt_utils.default_last_day"]
       },
       "description": "",
       "meta": {},
@@ -8160,9 +7519,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__split_part"
-        ]
+        "macros": ["macro.dbt_utils.default__split_part"]
       },
       "description": "",
       "meta": {},
@@ -8228,9 +7585,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__date_trunc"
-        ]
+        "macros": ["macro.dbt_utils.default__date_trunc"]
       },
       "description": "",
       "meta": {},
@@ -8274,9 +7629,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__create_schema"
-        ]
+        "macros": ["macro.dbt.default__create_schema"]
       },
       "description": "",
       "meta": {},
@@ -8298,9 +7651,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -8322,9 +7673,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__drop_schema"
-        ]
+        "macros": ["macro.dbt.default__drop_schema"]
       },
       "description": "",
       "meta": {},
@@ -8346,9 +7695,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -8370,9 +7717,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_create_index_sql"
-        ]
+        "macros": ["macro.dbt.default__get_create_index_sql"]
       },
       "description": "",
       "meta": {},
@@ -8416,9 +7761,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__create_indexes"
-        ]
+        "macros": ["macro.dbt.default__create_indexes"]
       },
       "description": "",
       "meta": {},
@@ -8440,10 +7783,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.get_create_index_sql",
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.get_create_index_sql", "macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -8465,9 +7805,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__make_intermediate_relation"
-        ]
+        "macros": ["macro.dbt.default__make_intermediate_relation"]
       },
       "description": "",
       "meta": {},
@@ -8489,9 +7827,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__make_temp_relation"
-        ]
+        "macros": ["macro.dbt.default__make_temp_relation"]
       },
       "description": "",
       "meta": {},
@@ -8513,9 +7849,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__make_temp_relation"
-        ]
+        "macros": ["macro.dbt.default__make_temp_relation"]
       },
       "description": "",
       "meta": {},
@@ -8559,9 +7893,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__make_backup_relation"
-        ]
+        "macros": ["macro.dbt.default__make_backup_relation"]
       },
       "description": "",
       "meta": {},
@@ -8605,9 +7937,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__drop_relation"
-        ]
+        "macros": ["macro.dbt.default__drop_relation"]
       },
       "description": "",
       "meta": {},
@@ -8629,9 +7959,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -8653,9 +7981,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__truncate_relation"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__truncate_relation"]
       },
       "description": "",
       "meta": {},
@@ -8677,9 +8003,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -8701,9 +8025,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__rename_relation"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__rename_relation"]
       },
       "description": "",
       "meta": {},
@@ -8725,9 +8047,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -8749,9 +8069,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_or_create_relation"
-        ]
+        "macros": ["macro.dbt.default__get_or_create_relation"]
       },
       "description": "",
       "meta": {},
@@ -8817,9 +8135,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.load_cached_relation"
-        ]
+        "macros": ["macro.dbt.load_cached_relation"]
       },
       "description": "",
       "meta": {},
@@ -8863,9 +8179,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__current_timestamp"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__current_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -8909,9 +8223,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__collect_freshness"
-        ]
+        "macros": ["macro.dbt.default__collect_freshness"]
       },
       "description": "",
       "meta": {},
@@ -8933,10 +8245,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement",
-          "macro.dbt_utils.current_timestamp"
-        ]
+        "macros": ["macro.dbt.statement", "macro.dbt_utils.current_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -8958,9 +8267,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__copy_grants"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__copy_grants"]
       },
       "description": "",
       "meta": {},
@@ -9050,9 +8357,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.copy_grants"
-        ]
+        "macros": ["macro.dbt.copy_grants"]
       },
       "description": "",
       "meta": {},
@@ -9074,9 +8379,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_show_grant_sql"
-        ]
+        "macros": ["macro.dbt.default__get_show_grant_sql"]
       },
       "description": "",
       "meta": {},
@@ -9120,9 +8423,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_grant_sql"
-        ]
+        "macros": ["macro.dbt.default__get_grant_sql"]
       },
       "description": "",
       "meta": {},
@@ -9166,9 +8467,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_revoke_sql"
-        ]
+        "macros": ["macro.dbt.default__get_revoke_sql"]
       },
       "description": "",
       "meta": {},
@@ -9212,9 +8511,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_dcl_statement_list"
-        ]
+        "macros": ["macro.dbt.default__get_dcl_statement_list"]
       },
       "description": "",
       "meta": {},
@@ -9236,9 +8533,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.support_multiple_grantees_per_dcl_statement"
-        ]
+        "macros": ["macro.dbt.support_multiple_grantees_per_dcl_statement"]
       },
       "description": "",
       "meta": {},
@@ -9260,9 +8555,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__call_dcl_statements"
-        ]
+        "macros": ["macro.dbt.default__call_dcl_statements"]
       },
       "description": "",
       "meta": {},
@@ -9284,9 +8577,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -9308,9 +8599,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__apply_grants"
-        ]
+        "macros": ["macro.dbt.default__apply_grants"]
       },
       "description": "",
       "meta": {},
@@ -9359,9 +8648,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__alter_column_comment"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__alter_column_comment"]
       },
       "description": "",
       "meta": {},
@@ -9405,9 +8692,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__alter_relation_comment"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__alter_relation_comment"]
       },
       "description": "",
       "meta": {},
@@ -9451,9 +8736,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__persist_docs"
-        ]
+        "macros": ["macro.dbt.default__persist_docs"]
       },
       "description": "",
       "meta": {},
@@ -9501,9 +8784,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__get_catalog"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__get_catalog"]
       },
       "description": "",
       "meta": {},
@@ -9547,9 +8828,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__information_schema_name"
-        ]
+        "macros": ["macro.dbt.default__information_schema_name"]
       },
       "description": "",
       "meta": {},
@@ -9593,9 +8872,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__list_schemas"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__list_schemas"]
       },
       "description": "",
       "meta": {},
@@ -9617,10 +8894,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.information_schema_name",
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.information_schema_name", "macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -9642,9 +8916,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__check_schema_exists"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__check_schema_exists"]
       },
       "description": "",
       "meta": {},
@@ -9666,10 +8938,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.replace",
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt_utils.replace", "macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -9737,9 +9006,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__get_columns_in_relation"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__get_columns_in_relation"]
       },
       "description": "",
       "meta": {},
@@ -9805,9 +9072,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__get_columns_in_query"
-        ]
+        "macros": ["macro.dbt.default__get_columns_in_query"]
       },
       "description": "",
       "meta": {},
@@ -9829,9 +9094,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -9853,9 +9116,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_snowflake.snowflake__alter_column_type"
-        ]
+        "macros": ["macro.dbt_snowflake.snowflake__alter_column_type"]
       },
       "description": "",
       "meta": {},
@@ -9877,9 +9138,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -9925,9 +9184,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -10042,9 +9299,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__test_unique"
-        ]
+        "macros": ["macro.dbt.default__test_unique"]
       },
       "description": "",
       "meta": {},
@@ -10066,9 +9321,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__test_not_null"
-        ]
+        "macros": ["macro.dbt.default__test_not_null"]
       },
       "description": "",
       "meta": {},
@@ -10090,9 +9343,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__test_accepted_values"
-        ]
+        "macros": ["macro.dbt.default__test_accepted_values"]
       },
       "description": "",
       "meta": {},
@@ -10114,9 +9365,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.default__test_relationships"
-        ]
+        "macros": ["macro.dbt.default__test_relationships"]
       },
       "description": "",
       "meta": {},
@@ -10138,9 +9387,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__except"
-        ]
+        "macros": ["macro.dbt_utils.default__except"]
       },
       "description": "",
       "meta": {},
@@ -10206,9 +9453,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__replace"
-        ]
+        "macros": ["macro.dbt_utils.default__replace"]
       },
       "description": "",
       "meta": {},
@@ -10252,9 +9497,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__concat"
-        ]
+        "macros": ["macro.dbt_utils.default__concat"]
       },
       "description": "",
       "meta": {},
@@ -10298,9 +9541,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__type_string"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__type_string"]
       },
       "description": "",
       "meta": {},
@@ -10410,9 +9651,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__type_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__type_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -10478,9 +9717,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_float"
-        ]
+        "macros": ["macro.dbt_utils.default__type_float"]
       },
       "description": "",
       "meta": {},
@@ -10546,9 +9783,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_numeric"
-        ]
+        "macros": ["macro.dbt_utils.default__type_numeric"]
       },
       "description": "",
       "meta": {},
@@ -10614,9 +9849,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_bigint"
-        ]
+        "macros": ["macro.dbt_utils.default__type_bigint"]
       },
       "description": "",
       "meta": {},
@@ -10682,9 +9915,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__type_int"
-        ]
+        "macros": ["macro.dbt_utils.default__type_int"]
       },
       "description": "",
       "meta": {},
@@ -10772,9 +10003,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__length"
-        ]
+        "macros": ["macro.dbt_utils.default__length"]
       },
       "description": "",
       "meta": {},
@@ -10840,9 +10069,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__dateadd"
-        ]
+        "macros": ["macro.dbt_utils.default__dateadd"]
       },
       "description": "",
       "meta": {},
@@ -10930,9 +10157,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__dateadd"
-        ]
+        "macros": ["macro.dbt_utils.default__dateadd"]
       },
       "description": "",
       "meta": {},
@@ -10954,9 +10179,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__intersect"
-        ]
+        "macros": ["macro.dbt_utils.default__intersect"]
       },
       "description": "",
       "meta": {},
@@ -11022,9 +10245,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__right"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__right"]
       },
       "description": "",
       "meta": {},
@@ -11112,9 +10333,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__datediff"
-        ]
+        "macros": ["macro.dbt_utils.default__datediff"]
       },
       "description": "",
       "meta": {},
@@ -11180,9 +10399,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.datediff"
-        ]
+        "macros": ["macro.dbt_utils.datediff"]
       },
       "description": "",
       "meta": {},
@@ -11204,9 +10421,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__datediff"
-        ]
+        "macros": ["macro.dbt_utils.default__datediff"]
       },
       "description": "",
       "meta": {},
@@ -11228,9 +10443,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__safe_cast"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__safe_cast"]
       },
       "description": "",
       "meta": {},
@@ -11318,9 +10531,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__hash"
-        ]
+        "macros": ["macro.dbt_utils.default__hash"]
       },
       "description": "",
       "meta": {},
@@ -11342,9 +10553,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.type_string"
-        ]
+        "macros": ["macro.dbt_utils.type_string"]
       },
       "description": "",
       "meta": {},
@@ -11366,9 +10575,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__hash"
-        ]
+        "macros": ["macro.dbt_utils.default__hash"]
       },
       "description": "",
       "meta": {},
@@ -11390,9 +10597,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__cast_bool_to_text"
-        ]
+        "macros": ["macro.dbt_utils.default__cast_bool_to_text"]
       },
       "description": "",
       "meta": {},
@@ -11414,9 +10619,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.type_string"
-        ]
+        "macros": ["macro.dbt_utils.type_string"]
       },
       "description": "",
       "meta": {},
@@ -11460,9 +10663,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__identifier"
-        ]
+        "macros": ["macro.dbt_utils.default__identifier"]
       },
       "description": "",
       "meta": {},
@@ -11528,9 +10729,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__position"
-        ]
+        "macros": ["macro.dbt_utils.default__position"]
       },
       "description": "",
       "meta": {},
@@ -11596,9 +10795,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__string_literal"
-        ]
+        "macros": ["macro.dbt_utils.default__string_literal"]
       },
       "description": "",
       "meta": {},
@@ -11642,9 +10839,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__current_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.default__current_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -11666,9 +10861,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.type_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.type_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -11734,9 +10927,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__current_timestamp_in_utc"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__current_timestamp_in_utc"]
       },
       "description": "",
       "meta": {},
@@ -11758,9 +10949,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.current_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.current_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -11807,9 +10996,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.type_timestamp"
-        ]
+        "macros": ["macro.dbt_utils.type_timestamp"]
       },
       "description": "",
       "meta": {},
@@ -11831,9 +11018,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__current_timestamp_in_utc"
-        ]
+        "macros": ["macro.dbt_utils.default__current_timestamp_in_utc"]
       },
       "description": "",
       "meta": {},
@@ -11855,9 +11040,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.snowflake__width_bucket"
-        ]
+        "macros": ["macro.dbt_utils.snowflake__width_bucket"]
       },
       "description": "",
       "meta": {},
@@ -11879,10 +11062,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.safe_cast",
-          "macro.dbt_utils.type_numeric"
-        ]
+        "macros": ["macro.dbt_utils.safe_cast", "macro.dbt_utils.type_numeric"]
       },
       "description": "",
       "meta": {},
@@ -11904,10 +11084,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.safe_cast",
-          "macro.dbt_utils.type_numeric"
-        ]
+        "macros": ["macro.dbt_utils.safe_cast", "macro.dbt_utils.type_numeric"]
       },
       "description": "",
       "meta": {},
@@ -11951,9 +11128,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__last_day"
-        ]
+        "macros": ["macro.dbt_utils.default__last_day"]
       },
       "description": "",
       "meta": {},
@@ -11975,10 +11150,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.dateadd",
-          "macro.dbt_utils.date_trunc"
-        ]
+        "macros": ["macro.dbt_utils.dateadd", "macro.dbt_utils.date_trunc"]
       },
       "description": "",
       "meta": {},
@@ -12000,9 +11172,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default_last_day"
-        ]
+        "macros": ["macro.dbt_utils.default_last_day"]
       },
       "description": "",
       "meta": {},
@@ -12050,9 +11220,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__last_day"
-        ]
+        "macros": ["macro.dbt_utils.default__last_day"]
       },
       "description": "",
       "meta": {},
@@ -12074,9 +11242,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__split_part"
-        ]
+        "macros": ["macro.dbt_utils.default__split_part"]
       },
       "description": "",
       "meta": {},
@@ -12142,9 +11308,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__date_trunc"
-        ]
+        "macros": ["macro.dbt_utils.default__date_trunc"]
       },
       "description": "",
       "meta": {},
@@ -12232,9 +11396,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_period_boundaries"
-        ]
+        "macros": ["macro.dbt_utils.default__get_period_boundaries"]
       },
       "description": "",
       "meta": {},
@@ -12283,9 +11445,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_period_sql"
-        ]
+        "macros": ["macro.dbt_utils.default__get_period_sql"]
       },
       "description": "",
       "meta": {},
@@ -12359,9 +11519,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_url_host"
-        ]
+        "macros": ["macro.dbt_utils.default__get_url_host"]
       },
       "description": "",
       "meta": {},
@@ -12410,9 +11568,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_url_path"
-        ]
+        "macros": ["macro.dbt_utils.default__get_url_path"]
       },
       "description": "",
       "meta": {},
@@ -12464,9 +11620,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_url_parameter"
-        ]
+        "macros": ["macro.dbt_utils.default__get_url_parameter"]
       },
       "description": "",
       "meta": {},
@@ -12488,9 +11642,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.split_part"
-        ]
+        "macros": ["macro.dbt_utils.split_part"]
       },
       "description": "",
       "meta": {},
@@ -12512,9 +11664,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__pretty_log_format"
-        ]
+        "macros": ["macro.dbt_utils.default__pretty_log_format"]
       },
       "description": "",
       "meta": {},
@@ -12536,9 +11686,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.pretty_time"
-        ]
+        "macros": ["macro.dbt_utils.pretty_time"]
       },
       "description": "",
       "meta": {},
@@ -12560,9 +11708,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__pretty_time"
-        ]
+        "macros": ["macro.dbt_utils.default__pretty_time"]
       },
       "description": "",
       "meta": {},
@@ -12606,9 +11752,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__log_info"
-        ]
+        "macros": ["macro.dbt_utils.default__log_info"]
       },
       "description": "",
       "meta": {},
@@ -12630,9 +11774,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.pretty_log_format"
-        ]
+        "macros": ["macro.dbt_utils.pretty_log_format"]
       },
       "description": "",
       "meta": {},
@@ -12676,9 +11818,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_fewer_rows_than"
-        ]
+        "macros": ["macro.dbt_utils.default__test_fewer_rows_than"]
       },
       "description": "",
       "meta": {},
@@ -12722,9 +11862,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_equal_rowcount"
-        ]
+        "macros": ["macro.dbt_utils.default__test_equal_rowcount"]
       },
       "description": "",
       "meta": {},
@@ -12768,9 +11906,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_relationships_where"
-        ]
+        "macros": ["macro.dbt_utils.default__test_relationships_where"]
       },
       "description": "",
       "meta": {},
@@ -12814,9 +11950,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_recency"
-        ]
+        "macros": ["macro.dbt_utils.default__test_recency"]
       },
       "description": "",
       "meta": {},
@@ -12863,9 +11997,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_not_constant"
-        ]
+        "macros": ["macro.dbt_utils.default__test_not_constant"]
       },
       "description": "",
       "meta": {},
@@ -12909,9 +12041,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_accepted_range"
-        ]
+        "macros": ["macro.dbt_utils.default__test_accepted_range"]
       },
       "description": "",
       "meta": {},
@@ -12955,9 +12085,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_not_accepted_values"
-        ]
+        "macros": ["macro.dbt_utils.default__test_not_accepted_values"]
       },
       "description": "",
       "meta": {},
@@ -13001,9 +12129,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_unique_where"
-        ]
+        "macros": ["macro.dbt_utils.default__test_unique_where"]
       },
       "description": "",
       "meta": {},
@@ -13025,9 +12151,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_unique"
-        ]
+        "macros": ["macro.dbt.test_unique"]
       },
       "description": "",
       "meta": {},
@@ -13049,9 +12173,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_at_least_one"
-        ]
+        "macros": ["macro.dbt_utils.default__test_at_least_one"]
       },
       "description": "",
       "meta": {},
@@ -13141,9 +12263,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_cardinality_equality"
-        ]
+        "macros": ["macro.dbt_utils.default__test_cardinality_equality"]
       },
       "description": "",
       "meta": {},
@@ -13165,9 +12285,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.except"
-        ]
+        "macros": ["macro.dbt_utils.except"]
       },
       "description": "",
       "meta": {},
@@ -13189,9 +12307,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_expression_is_true"
-        ]
+        "macros": ["macro.dbt_utils.default__test_expression_is_true"]
       },
       "description": "",
       "meta": {},
@@ -13235,9 +12351,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_not_null_proportion"
-        ]
+        "macros": ["macro.dbt_utils.default__test_not_null_proportion"]
       },
       "description": "",
       "meta": {},
@@ -13281,9 +12395,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_sequential_values"
-        ]
+        "macros": ["macro.dbt_utils.default__test_sequential_values"]
       },
       "description": "",
       "meta": {},
@@ -13305,10 +12417,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.type_timestamp",
-          "macro.dbt_utils.dateadd"
-        ]
+        "macros": ["macro.dbt_utils.type_timestamp", "macro.dbt_utils.dateadd"]
       },
       "description": "",
       "meta": {},
@@ -13330,9 +12439,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_not_null_where"
-        ]
+        "macros": ["macro.dbt_utils.default__test_not_null_where"]
       },
       "description": "",
       "meta": {},
@@ -13354,9 +12461,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.test_not_null"
-        ]
+        "macros": ["macro.dbt.test_not_null"]
       },
       "description": "",
       "meta": {},
@@ -13378,9 +12483,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_equality"
-        ]
+        "macros": ["macro.dbt_utils.default__test_equality"]
       },
       "description": "",
       "meta": {},
@@ -13428,9 +12531,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__test_mutually_exclusive_ranges"
-        ]
+        "macros": ["macro.dbt_utils.default__test_mutually_exclusive_ranges"]
       },
       "description": "",
       "meta": {},
@@ -13474,9 +12575,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_intervals_between"
-        ]
+        "macros": ["macro.dbt_utils.default__get_intervals_between"]
       },
       "description": "",
       "meta": {},
@@ -13498,10 +12597,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement",
-          "macro.dbt_utils.datediff"
-        ]
+        "macros": ["macro.dbt.statement", "macro.dbt_utils.datediff"]
       },
       "description": "",
       "meta": {},
@@ -13523,9 +12619,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__date_spine"
-        ]
+        "macros": ["macro.dbt_utils.default__date_spine"]
       },
       "description": "",
       "meta": {},
@@ -13573,9 +12667,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__nullcheck_table"
-        ]
+        "macros": ["macro.dbt_utils.default__nullcheck_table"]
       },
       "description": "",
       "meta": {},
@@ -13623,9 +12715,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_relations_by_pattern"
-        ]
+        "macros": ["macro.dbt_utils.default__get_relations_by_pattern"]
       },
       "description": "",
       "meta": {},
@@ -13672,9 +12762,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_powers_of_two"
-        ]
+        "macros": ["macro.dbt_utils.default__get_powers_of_two"]
       },
       "description": "",
       "meta": {},
@@ -13718,9 +12806,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__generate_series"
-        ]
+        "macros": ["macro.dbt_utils.default__generate_series"]
       },
       "description": "",
       "meta": {},
@@ -13742,9 +12828,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.get_powers_of_two"
-        ]
+        "macros": ["macro.dbt_utils.get_powers_of_two"]
       },
       "description": "",
       "meta": {},
@@ -13766,9 +12850,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_relations_by_prefix"
-        ]
+        "macros": ["macro.dbt_utils.default__get_relations_by_prefix"]
       },
       "description": "",
       "meta": {},
@@ -13815,9 +12897,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_tables_by_prefix_sql"
-        ]
+        "macros": ["macro.dbt_utils.default__get_tables_by_prefix_sql"]
       },
       "description": "",
       "meta": {},
@@ -13839,9 +12919,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.get_tables_by_pattern_sql"
-        ]
+        "macros": ["macro.dbt_utils.get_tables_by_pattern_sql"]
       },
       "description": "",
       "meta": {},
@@ -13863,9 +12941,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__star"
-        ]
+        "macros": ["macro.dbt_utils.default__star"]
       },
       "description": "",
       "meta": {},
@@ -13912,9 +12988,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__unpivot"
-        ]
+        "macros": ["macro.dbt_utils.default__unpivot"]
       },
       "description": "",
       "meta": {},
@@ -13963,9 +13037,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__union_relations"
-        ]
+        "macros": ["macro.dbt_utils.default__union_relations"]
       },
       "description": "",
       "meta": {},
@@ -14014,9 +13086,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__group_by"
-        ]
+        "macros": ["macro.dbt_utils.default__group_by"]
       },
       "description": "",
       "meta": {},
@@ -14060,9 +13130,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__surrogate_key"
-        ]
+        "macros": ["macro.dbt_utils.default__surrogate_key"]
       },
       "description": "",
       "meta": {},
@@ -14110,9 +13178,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__safe_add"
-        ]
+        "macros": ["macro.dbt_utils.default__safe_add"]
       },
       "description": "",
       "meta": {},
@@ -14156,9 +13222,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__nullcheck"
-        ]
+        "macros": ["macro.dbt_utils.default__nullcheck"]
       },
       "description": "",
       "meta": {},
@@ -14202,9 +13266,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_tables_by_pattern_sql"
-        ]
+        "macros": ["macro.dbt_utils.default__get_tables_by_pattern_sql"]
       },
       "description": "",
       "meta": {},
@@ -14248,9 +13310,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils._bigquery__get_matching_schemata"
-        ]
+        "macros": ["macro.dbt_utils._bigquery__get_matching_schemata"]
       },
       "description": "",
       "meta": {},
@@ -14272,9 +13332,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.run_query"
-        ]
+        "macros": ["macro.dbt.run_query"]
       },
       "description": "",
       "meta": {},
@@ -14296,9 +13354,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_column_values"
-        ]
+        "macros": ["macro.dbt_utils.default__get_column_values"]
       },
       "description": "",
       "meta": {},
@@ -14320,9 +13376,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -14344,9 +13398,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__pivot"
-        ]
+        "macros": ["macro.dbt_utils.default__pivot"]
       },
       "description": "",
       "meta": {},
@@ -14368,9 +13420,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.slugify"
-        ]
+        "macros": ["macro.dbt_utils.slugify"]
       },
       "description": "",
       "meta": {},
@@ -14392,9 +13442,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__get_query_results_as_dict"
-        ]
+        "macros": ["macro.dbt_utils.default__get_query_results_as_dict"]
       },
       "description": "",
       "meta": {},
@@ -14416,9 +13464,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt.statement"
-        ]
+        "macros": ["macro.dbt.statement"]
       },
       "description": "",
       "meta": {},
@@ -14462,9 +13508,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.default__haversine_distance"
-        ]
+        "macros": ["macro.dbt_utils.default__haversine_distance"]
       },
       "description": "",
       "meta": {},
@@ -14508,9 +13552,7 @@
       "resource_type": "macro",
       "tags": [],
       "depends_on": {
-        "macros": [
-          "macro.dbt_utils.degrees_to_radians"
-        ]
+        "macros": ["macro.dbt_utils.degrees_to_radians"]
       },
       "description": "",
       "meta": {},
@@ -14571,10 +13613,7 @@
   },
   "exposures": {
     "exposure.jaffle_shop.crm_export": {
-      "fqn": [
-        "jaffle_shop",
-        "crm_export"
-      ],
+      "fqn": ["jaffle_shop", "crm_export"],
       "unique_id": "exposure.jaffle_shop.crm_export",
       "package_name": "jaffle_shop",
       "root_path": "/Users/jerco/dev/product/dbt-docs/ci-project",
@@ -14599,22 +13638,12 @@
           "model.jaffle_shop.dim_customers"
         ]
       },
-      "refs": [
-        [
-          "fct_orders"
-        ],
-        [
-          "dim_customers"
-        ]
-      ],
+      "refs": [["fct_orders"], ["dim_customers"]],
       "sources": [],
       "created_at": 1658917993.582535
     },
     "exposure.jaffle_shop.weekly_metrics": {
-      "fqn": [
-        "jaffle_shop",
-        "weekly_metrics"
-      ],
+      "fqn": ["jaffle_shop", "weekly_metrics"],
       "unique_id": "exposure.jaffle_shop.weekly_metrics",
       "package_name": "jaffle_shop",
       "root_path": "/Users/jerco/dev/product/dbt-docs/ci-project",
@@ -14634,23 +13663,14 @@
       "url": "https://www.getdbt.com",
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.dim_customers"
-        ]
+        "nodes": ["model.jaffle_shop.dim_customers"]
       },
-      "refs": [
-        [
-          "dim_customers"
-        ]
-      ],
+      "refs": [["dim_customers"]],
       "sources": [],
       "created_at": 1658917993.584429
     },
     "exposure.jaffle_shop.company_projections": {
-      "fqn": [
-        "jaffle_shop",
-        "company_projections"
-      ],
+      "fqn": ["jaffle_shop", "company_projections"],
       "unique_id": "exposure.jaffle_shop.company_projections",
       "package_name": "jaffle_shop",
       "root_path": "/Users/jerco/dev/product/dbt-docs/ci-project",
@@ -14670,25 +13690,16 @@
       "url": null,
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "sources": [],
       "created_at": 1658917993.5860538
     }
   },
   "metrics": {
     "metric.jaffle_shop.count_orders": {
-      "fqn": [
-        "jaffle_shop",
-        "count_orders"
-      ],
+      "fqn": ["jaffle_shop", "count_orders"],
       "unique_id": "metric.jaffle_shop.count_orders",
       "package_name": "jaffle_shop",
       "root_path": "/Users/jerco/dev/product/dbt-docs/ci-project",
@@ -14701,12 +13712,7 @@
       "sql": "*",
       "timestamp": "order_date",
       "filters": [],
-      "time_grains": [
-        "day",
-        "week",
-        "month",
-        "year"
-      ],
+      "time_grains": ["day", "week", "month", "year"],
       "dimensions": [],
       "model": "ref('fct_orders')",
       "model_unique_id": null,
@@ -14716,23 +13722,14 @@
       "sources": [],
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.fct_orders"
-        ]
+        "nodes": ["model.jaffle_shop.fct_orders"]
       },
-      "refs": [
-        [
-          "fct_orders"
-        ]
-      ],
+      "refs": [["fct_orders"]],
       "metrics": [],
       "created_at": 1658917993.577698
     },
     "metric.jaffle_shop.cohorted_lifetime_value": {
-      "fqn": [
-        "jaffle_shop",
-        "cohorted_lifetime_value"
-      ],
+      "fqn": ["jaffle_shop", "cohorted_lifetime_value"],
       "unique_id": "metric.jaffle_shop.cohorted_lifetime_value",
       "package_name": "jaffle_shop",
       "root_path": "/Users/jerco/dev/product/dbt-docs/ci-project",
@@ -14745,11 +13742,7 @@
       "sql": "customer_lifetime_value",
       "timestamp": "first_order",
       "filters": [],
-      "time_grains": [
-        "week",
-        "month",
-        "year"
-      ],
+      "time_grains": ["week", "month", "year"],
       "dimensions": [],
       "model": "ref('dim_customers')",
       "model_unique_id": null,
@@ -14759,15 +13752,9 @@
       "sources": [],
       "depends_on": {
         "macros": [],
-        "nodes": [
-          "model.jaffle_shop.dim_customers"
-        ]
+        "nodes": ["model.jaffle_shop.dim_customers"]
       },
-      "refs": [
-        [
-          "dim_customers"
-        ]
-      ],
+      "refs": [["dim_customers"]],
       "metrics": [],
       "created_at": 1658917993.579798
     }
@@ -14775,12 +13762,8 @@
   "selectors": {},
   "disabled": {},
   "parent_map": {
-    "model.jaffle_shop.stg_payments": [
-      "seed.jaffle_shop.raw_payments"
-    ],
-    "model.jaffle_shop.stg_orders": [
-      "seed.jaffle_shop.raw_orders"
-    ],
+    "model.jaffle_shop.stg_payments": ["seed.jaffle_shop.raw_payments"],
+    "model.jaffle_shop.stg_orders": ["seed.jaffle_shop.raw_orders"],
     "model.jaffle_shop.hidden_model": [
       "model.jaffle_shop.stg_orders",
       "source.jaffle_shop.payments.orders"
@@ -14789,28 +13772,16 @@
       "model.jaffle_shop.order_payments",
       "model.jaffle_shop.stg_orders"
     ],
-    "model.jaffle_shop.order_payments": [
-      "model.jaffle_shop.stg_payments"
-    ],
+    "model.jaffle_shop.order_payments": ["model.jaffle_shop.stg_payments"],
     "model.jaffle_shop.customer_payments": [
       "model.jaffle_shop.stg_orders",
       "model.jaffle_shop.stg_payments"
     ],
-    "model.jaffle_shop.customer_orders": [
-      "model.jaffle_shop.stg_orders"
-    ],
-    "model.jaffle_shop.holiday_orders": [
-      "model.jaffle_shop.stg_orders"
-    ],
-    "analysis.jaffle_shop.my_analysis": [
-      "model.jaffle_shop.stg_orders"
-    ],
-    "test.jaffle_shop.example_data_test": [
-      "model.jaffle_shop.stg_orders"
-    ],
-    "test.jaffle_shop.tagged_data_test": [
-      "model.jaffle_shop.stg_customers"
-    ],
+    "model.jaffle_shop.customer_orders": ["model.jaffle_shop.stg_orders"],
+    "model.jaffle_shop.holiday_orders": ["model.jaffle_shop.stg_orders"],
+    "analysis.jaffle_shop.my_analysis": ["model.jaffle_shop.stg_orders"],
+    "test.jaffle_shop.example_data_test": ["model.jaffle_shop.stg_orders"],
+    "test.jaffle_shop.tagged_data_test": ["model.jaffle_shop.stg_customers"],
     "seed.jaffle_shop.raw_orders": [],
     "seed.jaffle_shop.raw_payments": [],
     "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [
@@ -14870,9 +13841,7 @@
       "model.jaffle_shop.customer_payments",
       "model.jaffle_shop.stg_customers"
     ],
-    "model.jaffle_shop.stg_customers": [
-      "seed.jaffle_shop.raw_customers"
-    ],
+    "model.jaffle_shop.stg_customers": ["seed.jaffle_shop.raw_customers"],
     "seed.jaffle_shop.raw_customers": [],
     "test.jaffle_shop.unique_dim_customers_customer_id.15c9f1e2fd": [
       "model.jaffle_shop.dim_customers"
@@ -14892,15 +13861,11 @@
       "model.jaffle_shop.dim_customers",
       "model.jaffle_shop.fct_orders"
     ],
-    "exposure.jaffle_shop.weekly_metrics": [
-      "model.jaffle_shop.dim_customers"
-    ],
+    "exposure.jaffle_shop.weekly_metrics": ["model.jaffle_shop.dim_customers"],
     "exposure.jaffle_shop.company_projections": [
       "model.jaffle_shop.fct_orders"
     ],
-    "metric.jaffle_shop.count_orders": [
-      "model.jaffle_shop.fct_orders"
-    ],
+    "metric.jaffle_shop.count_orders": ["model.jaffle_shop.fct_orders"],
     "metric.jaffle_shop.cohorted_lifetime_value": [
       "model.jaffle_shop.dim_customers"
     ]
@@ -14942,25 +13907,15 @@
       "test.jaffle_shop.relationships_fct_orders_customer_id__customer_id__ref_dim_customers_.d5636051d4",
       "test.jaffle_shop.unique_fct_orders_order_id.523ddb6ce5"
     ],
-    "model.jaffle_shop.order_payments": [
-      "model.jaffle_shop.fct_orders"
-    ],
-    "model.jaffle_shop.customer_payments": [
-      "model.jaffle_shop.dim_customers"
-    ],
-    "model.jaffle_shop.customer_orders": [
-      "model.jaffle_shop.dim_customers"
-    ],
+    "model.jaffle_shop.order_payments": ["model.jaffle_shop.fct_orders"],
+    "model.jaffle_shop.customer_payments": ["model.jaffle_shop.dim_customers"],
+    "model.jaffle_shop.customer_orders": ["model.jaffle_shop.dim_customers"],
     "model.jaffle_shop.holiday_orders": [],
     "analysis.jaffle_shop.my_analysis": [],
     "test.jaffle_shop.example_data_test": [],
     "test.jaffle_shop.tagged_data_test": [],
-    "seed.jaffle_shop.raw_orders": [
-      "model.jaffle_shop.stg_orders"
-    ],
-    "seed.jaffle_shop.raw_payments": [
-      "model.jaffle_shop.stg_payments"
-    ],
+    "seed.jaffle_shop.raw_orders": ["model.jaffle_shop.stg_orders"],
+    "seed.jaffle_shop.raw_payments": ["model.jaffle_shop.stg_payments"],
     "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [],
     "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [],
     "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
@@ -14992,16 +13947,12 @@
       "test.jaffle_shop.tagged_data_test",
       "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"
     ],
-    "seed.jaffle_shop.raw_customers": [
-      "model.jaffle_shop.stg_customers"
-    ],
+    "seed.jaffle_shop.raw_customers": ["model.jaffle_shop.stg_customers"],
     "test.jaffle_shop.unique_dim_customers_customer_id.15c9f1e2fd": [],
     "test.jaffle_shop.not_null_dim_customers_customer_id.dd91cd1c8d": [],
     "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [],
     "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
-    "source.jaffle_shop.payments.orders": [
-      "model.jaffle_shop.hidden_model"
-    ],
+    "source.jaffle_shop.payments.orders": ["model.jaffle_shop.hidden_model"],
     "source.jaffle_shop.payments.tagged_source": [],
     "exposure.jaffle_shop.crm_export": [],
     "exposure.jaffle_shop.weekly_metrics": [],

--- a/tests/tests_jinja_tools/tests_dbt_dataclasses/__init__.py
+++ b/tests/tests_jinja_tools/tests_dbt_dataclasses/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic Dataclasses for safe loading of manifest.json."""

--- a/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
+++ b/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
@@ -2,7 +2,7 @@
 from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import DbtModel
 
 
-def test_load_manifest_json(single_dbt_model_json):
+def test_load_manifest_json(single_dbt_model_json: dict) -> None:
     """Basic smoke test for the maifest loaders."""
     dbt_obj = DbtModel(**single_dbt_model_json)
     assert dbt_obj.columns

--- a/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
+++ b/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
@@ -1,8 +1,12 @@
 """Tests around the validation of manifest.json."""
-from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import DbtModel
+import typing
+
+from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import (
+    DbtModel,  # type: ignore[import]
+)
 
 
-def test_load_manifest_json(single_dbt_model_json: dict) -> None:
+def test_load_manifest_json(single_dbt_model_json: dict[str, typing.Any]) -> None:
     """Basic smoke test for the maifest loaders."""
     dbt_obj = DbtModel(**single_dbt_model_json)
     assert dbt_obj.columns

--- a/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
+++ b/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
@@ -1,0 +1,8 @@
+"""Tests around the validation of manifest.json."""
+from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import DbtModel
+
+
+def test_load_manifest_json(single_dbt_model_json):
+    """Basic smoke test for the maifest loaders."""
+    dbt_obj = DbtModel(**single_dbt_model_json)
+    assert dbt_obj.columns

--- a/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
+++ b/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
@@ -1,9 +1,7 @@
 """Tests around the validation of manifest.json."""
 import typing
 
-from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import (
-    DbtModel,  # type: ignore[import]
-)
+from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import DbtModel
 
 
 def test_load_manifest_json(

--- a/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
+++ b/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
@@ -2,11 +2,13 @@
 import typing
 
 from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import (
-    DbtModel,  # type: ignore[import]
+    DbtModel,  # type: ignore [import]
 )
 
 
-def test_load_manifest_json(single_dbt_model_json: dict[str, typing.Any]) -> None:
+def test_load_manifest_json(
+    single_dbt_model_json: typing.Dict[str, typing.Any]
+) -> None:
     """Basic smoke test for the maifest loaders."""
     dbt_obj = DbtModel(**single_dbt_model_json)
     assert dbt_obj.columns

--- a/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
+++ b/tests/tests_jinja_tools/tests_dbt_dataclasses/test_manifest_objects.py
@@ -2,7 +2,7 @@
 import typing
 
 from src.dbt_jinja_tests.jinja_tools.dbt_dataclasses.model_config import (
-    DbtModel,  # type: ignore [import]
+    DbtModel,  # type: ignore[import]
 )
 
 


### PR DESCRIPTION
Manfiest.json files are one of the key parts of statically parsing a dbt project and setting up model inheritance. Careful parsing and path validation will hopefully save a lot of debugging down the line as compared to more yolo strategies.